### PR TITLE
Redirect main TO products direct to TO github repo

### DIFF
--- a/config/to.yml
+++ b/config/to.yml
@@ -4,8 +4,8 @@ id: TO
 base_url: /obo/to
 
 products:
-- to.owl: http://www.berkeleybop.org/ontologies/to.owl
-- to.obo: http://www.berkeleybop.org/ontologies/to.obo
+- to.owl: https://raw.githubusercontent.com/Planteome/plant-trait-ontology/master/to.owl
+- to.obo: https://raw.githubusercontent.com/Planteome/plant-trait-ontology/master/to.obo
 
 term_browser: ontobee
 example_terms:


### PR DESCRIPTION
cc @cooperl09 @jaiswalp -- note that previously the TO PURLs were resolving to the nightly OBO central build at berkeley. This gives you direct control of releases. If you follow the instructions in the README you can make the releases appear automatically. We'll want to do this for your other ontologies too