### PR TITLE
Github tracker

### DIFF
--- a/config/hp.yml
+++ b/config/hp.yml
@@ -19,7 +19,7 @@ entries:
   replacement: https://compbio.charite.de/svn/hpo/releases/
 
 - prefix: /tracker
-  replacement: http://sourceforge.net/p/obo/human-phenotype-requests
+  replacement: https://github.com/obophenotype/human-phenotype-ontology/issues
 
 - prefix: /about/
   replacement: http://www.ontobee.org/browser/rdf.php?o=HP&iri=http://purl.obolibrary.org/obo/


### PR DESCRIPTION
We have moved the tracker from sourceforge to github.