### PR TITLE
update micro.yml to current URL of ontology and added example ID

### DIFF
--- a/config/micro.yml
+++ b/config/micro.yml
@@ -4,6 +4,9 @@ idspace: MICRO
 base_url: /obo/micro
 
 products:
-- micro.owl: https://raw.githubusercontent.com/carrineblank/MicrO/master/MicrOandImportModules/MicrO.Oct15.owl
+- micro.owl: https://raw.githubusercontent.com/carrineblank/MicrO/master/MicrOandImportModules/MicrO.owl
 
 term_browser: ontobee
+
+example_terms:
+- MICRO_0000000


### PR DESCRIPTION
Please pull the changes to the MicrO YAML file. They were minor changes (updating main PURL and adding ID example.