### PR TITLE
genepio initial configuration

### DIFF
--- a/config/genepio.yml
+++ b/config/genepio.yml
@@ -1,0 +1,15 @@
+# PURL configuration for http://purl.obolibrary.org/obo/genepio
+
+idspace: GENEPIO
+base_url: /obo/genepio
+
+products:
+- genepio.owl: https://raw.githubusercontent.com/GenEpiO/genepio/master/genepio.owl
+
+term_browser: ontobee
+example_terms:
+- GENEPIO_0000021
+
+entries:
+- prefix: /imports/
+  replacement: https://raw.githubusercontent.com/GenEpiO/genepio/master/src/imports/


### PR DESCRIPTION
One question: I can't quite tell if github's genpio/imports/ folder should be referred to below with /src/ or without?  (Same question for the foodon config too).  Thanks.

https://raw.githubusercontent.com/GenEpiO/genepio/master/src/imports/