### PR TITLE
Update to handle new versioning 

### DIFF
--- a/config/fbbt.yml
+++ b/config/fbbt.yml
@@ -33,31 +33,31 @@ entries:
 - exact: /vfb/vfb.owl
   replacement: http://virtualflybrain.org/owl/vfb.owl
   
-- regex: ^/vfb/(2016-0[0-7]-[0-9][0-9])/vfb\.owl&
+- regex: ^/obo/fbbt/vfb/(2016-0[0-7]-[0-9][0-9])/vfb\.owl&
   replacement: https://raw.githubusercontent.com/VirtualFlyBrain/VFB_owl/Archive/src/owl/$1/vfb.owl.gz
   tests:
   - from: /vfb/2016-01-21/vfb.owl
     to: https://raw.githubusercontent.com/VirtualFlyBrain/VFB_owl/Archive/src/owl/2016-01-21/vfb.owl.gz
   
-- regex: ^/vfb/(2016-0[0-7]-[0-9][0-9])/fbbt_(.*)\.owl$
+- regex: ^/obo/fbbt/vfb/(2016-0[0-7]-[0-9][0-9])/fbbt_(.*)\.owl$
   replacement: https://raw.githubusercontent.com/VirtualFlyBrain/VFB_owl/Archive/src/owl/$1/fbbt_$2.owl
   tests:
   - from: /vfb/2016-01-21/fbbt_vfb_ind.owl
     to: https://raw.githubusercontent.com/VirtualFlyBrain/VFB_owl/Archive/src/owl/2016-01-21/fbbt_vfb_ind.owl.gz
   
-- regex: ^/vfb/(201[5-6]-0[0-7]-[0-9][0-9])/$
+- regex: ^/obo/fbbt/vfb/(201[5-6]-0[0-7]-[0-9][0-9])/$
   replacement: https://raw.githubusercontent.com/VirtualFlyBrain/VFB_owl/Archive/src/owl/$1/
   tests:
   - from: /vfb/2016-01-21/
     to: https://raw.githubusercontent.com/VirtualFlyBrain/VFB_owl/Archive/src/owl/2016-01-21/
 
-- regex: ^/vfb/(20.*)/vfb\.owl$
+- regex: ^/obo/fbbt/vfb/(20.*)/vfb\.owl$
   replacement: https://raw.githubusercontent.com/VirtualFlyBrain/VFB_owl/$1/src/owl/vfb.owl.gz
   tests:
   - from: /vfb/2016-07-12/vfb.owl
     to: https://raw.githubusercontent.com/VirtualFlyBrain/VFB_owl/2016-07-12/src/owl/vfb.owl.gz
 
-- regex: ^/vfb/(20.*)/$
+- regex: ^/obo/fbbt/vfb/(20.*)/$
   replacement: https://raw.githubusercontent.com/VirtualFlyBrain/VFB_owl/$1/src/owl/
   tests:
   - from: /vfb/2016-07-12/

--- a/config/fbbt.yml
+++ b/config/fbbt.yml
@@ -33,14 +33,35 @@ entries:
 - exact: /vfb/vfb.owl
   replacement: http://virtualflybrain.org/owl/vfb.owl
   
-- exact: vfb.owl
-  replacement: vfb.owl.gz
+- exact: /vfb/(2016-0[0-7]-[0-9][0-9])/vfb.owl
+  replacement: https://raw.githubusercontent.com/VirtualFlyBrain/VFB_owl/Archive/src/owl/$1/vfb.owl.gz
+  tests:
+  - from: /vfb/2016-01-21/vfb.owl
+    to: https://raw.githubusercontent.com/VirtualFlyBrain/VFB_owl/Archive/src/owl/2016-01-21/vfb.owl.gz
+  
+- exact: /vfb/(2016-0[0-7]-[0-9][0-9])/fbbt_(.*).owl
+  replacement: https://raw.githubusercontent.com/VirtualFlyBrain/VFB_owl/Archive/src/owl/$1/fbbt_$2.owl
+  tests:
+  - from: /vfb/2016-01-21/fbbt_vfb_ind.owl
+    to: https://raw.githubusercontent.com/VirtualFlyBrain/VFB_owl/Archive/src/owl/2016-01-21/fbbt_vfb_ind.owl.gz
   
 - exact: /vfb/(201[5-6]-0[0-7]-[0-9][0-9])/
   replacement: https://raw.githubusercontent.com/VirtualFlyBrain/VFB_owl/Archive/src/owl/$1/
+  tests:
+  - from: /vfb/2016-01-21/fbbt_vfb_ind.owl
+    to: https://raw.githubusercontent.com/VirtualFlyBrain/VFB_owl/Archive/src/owl/2016-01-21/fbbt_vfb_ind.owl.gz
+
+- exact: /vfb/(20.*)/vfb.owl
+  replacement: https://raw.githubusercontent.com/VirtualFlyBrain/VFB_owl/$1/src/owl/vfb.owl.gz
+  tests:
+  - from: /vfb/2016-07-12/vfb.owl
+    to: https://raw.githubusercontent.com/VirtualFlyBrain/VFB_owl/2016-07-12/src/owl/vfb.owl.gz
 
 - exact: /vfb/(20.*)/
   replacement: https://raw.githubusercontent.com/VirtualFlyBrain/VFB_owl/$1/src/owl/
+  tests:
+  - from: /vfb/2016-07-12/
+    to: https://raw.githubusercontent.com/VirtualFlyBrain/VFB_owl/2016-07-12/src/owl/
 
 - prefix: /vfb/
   replacement: https://raw.githubusercontent.com/VirtualFlyBrain/VFB_owl/Current/src/owl/

--- a/config/fbbt.yml
+++ b/config/fbbt.yml
@@ -32,6 +32,15 @@ entries:
   
 - exact: /vfb/vfb.owl
   replacement: http://virtualflybrain.org/owl/vfb.owl
+  
+- exact: vfb.owl
+  replacement: vfb.owl.gz
+  
+- exact: /vfb/(201[5-6]-0[0-7]-[0-9][0-9])/
+  replacement: https://raw.githubusercontent.com/VirtualFlyBrain/VFB_owl/Archive/src/owl/$1/
+
+- exact: /vfb/(20.*)/
+  replacement: https://raw.githubusercontent.com/VirtualFlyBrain/VFB_owl/$1/src/owl/
 
 - prefix: /vfb/
   replacement: https://raw.githubusercontent.com/VirtualFlyBrain/VFB_owl/Current/src/owl/

--- a/config/fbbt.yml
+++ b/config/fbbt.yml
@@ -43,7 +43,7 @@ entries:
   replacement: https://raw.githubusercontent.com/VirtualFlyBrain/VFB_owl/Archive/src/owl/$1/fbbt_$2.owl
   tests:
   - from: /vfb/2016-01-21/fbbt_vfb_ind.owl
-    to: https://raw.githubusercontent.com/VirtualFlyBrain/VFB_owl/Archive/src/owl/2016-01-21/fbbt_vfb_ind.owl.gz
+    to: https://raw.githubusercontent.com/VirtualFlyBrain/VFB_owl/Archive/src/owl/2016-01-21/fbbt_vfb_ind.owl
   
 - regex: ^/obo/fbbt/vfb/(201[5-6]-0[0-6]-[0-9][0-9])/$
   replacement: https://raw.githubusercontent.com/VirtualFlyBrain/VFB_owl/Archive/src/owl/$1/

--- a/config/fbbt.yml
+++ b/config/fbbt.yml
@@ -33,7 +33,7 @@ entries:
 - exact: /vfb/vfb.owl
   replacement: http://virtualflybrain.org/owl/vfb.owl
   
-- regex: ^/obo/fbbt/vfb/(2016-0[0-7]-[0-9][0-9])/vfb\.owl&
+- regex: ^/obo/fbbt/vfb/(2016-0[0-7]-[0-9][0-9])/vfb\.owl$
   replacement: https://raw.githubusercontent.com/VirtualFlyBrain/VFB_owl/Archive/src/owl/$1/vfb.owl.gz
   tests:
   - from: /vfb/2016-01-21/vfb.owl

--- a/config/fbbt.yml
+++ b/config/fbbt.yml
@@ -33,13 +33,13 @@ entries:
 - exact: /vfb/vfb.owl
   replacement: http://virtualflybrain.org/owl/vfb.owl
   
-- regex: ^/vfb/(2016-0[0-7]-[0-9][0-9])/vfb.owl&
+- regex: ^/vfb/(2016-0[0-7]-[0-9][0-9])/vfb\.owl&
   replacement: https://raw.githubusercontent.com/VirtualFlyBrain/VFB_owl/Archive/src/owl/$1/vfb.owl.gz
   tests:
   - from: /vfb/2016-01-21/vfb.owl
     to: https://raw.githubusercontent.com/VirtualFlyBrain/VFB_owl/Archive/src/owl/2016-01-21/vfb.owl.gz
   
-- regex: ^/vfb/(2016-0[0-7]-[0-9][0-9])/fbbt_(.*).owl$
+- regex: ^/vfb/(2016-0[0-7]-[0-9][0-9])/fbbt_(.*)\.owl$
   replacement: https://raw.githubusercontent.com/VirtualFlyBrain/VFB_owl/Archive/src/owl/$1/fbbt_$2.owl
   tests:
   - from: /vfb/2016-01-21/fbbt_vfb_ind.owl
@@ -48,10 +48,10 @@ entries:
 - regex: ^/vfb/(201[5-6]-0[0-7]-[0-9][0-9])/$
   replacement: https://raw.githubusercontent.com/VirtualFlyBrain/VFB_owl/Archive/src/owl/$1/
   tests:
-  - from: /vfb/2016-01-21/fbbt_vfb_ind.owl
-    to: https://raw.githubusercontent.com/VirtualFlyBrain/VFB_owl/Archive/src/owl/2016-01-21/fbbt_vfb_ind.owl.gz
+  - from: /vfb/2016-01-21/
+    to: https://raw.githubusercontent.com/VirtualFlyBrain/VFB_owl/Archive/src/owl/2016-01-21/
 
-- regex: ^/vfb/(20.*)/vfb.owl$
+- regex: ^/vfb/(20.*)/vfb\.owl$
   replacement: https://raw.githubusercontent.com/VirtualFlyBrain/VFB_owl/$1/src/owl/vfb.owl.gz
   tests:
   - from: /vfb/2016-07-12/vfb.owl

--- a/config/fbbt.yml
+++ b/config/fbbt.yml
@@ -33,31 +33,31 @@ entries:
 - exact: /vfb/vfb.owl
   replacement: http://virtualflybrain.org/owl/vfb.owl
   
-- exact: /vfb/(2016-0[0-7]-[0-9][0-9])/vfb.owl
+- regex: ^/vfb/(2016-0[0-7]-[0-9][0-9])/vfb.owl&
   replacement: https://raw.githubusercontent.com/VirtualFlyBrain/VFB_owl/Archive/src/owl/$1/vfb.owl.gz
   tests:
   - from: /vfb/2016-01-21/vfb.owl
     to: https://raw.githubusercontent.com/VirtualFlyBrain/VFB_owl/Archive/src/owl/2016-01-21/vfb.owl.gz
   
-- exact: /vfb/(2016-0[0-7]-[0-9][0-9])/fbbt_(.*).owl
+- regex: ^/vfb/(2016-0[0-7]-[0-9][0-9])/fbbt_(.*).owl$
   replacement: https://raw.githubusercontent.com/VirtualFlyBrain/VFB_owl/Archive/src/owl/$1/fbbt_$2.owl
   tests:
   - from: /vfb/2016-01-21/fbbt_vfb_ind.owl
     to: https://raw.githubusercontent.com/VirtualFlyBrain/VFB_owl/Archive/src/owl/2016-01-21/fbbt_vfb_ind.owl.gz
   
-- exact: /vfb/(201[5-6]-0[0-7]-[0-9][0-9])/
+- regex: ^/vfb/(201[5-6]-0[0-7]-[0-9][0-9])/$
   replacement: https://raw.githubusercontent.com/VirtualFlyBrain/VFB_owl/Archive/src/owl/$1/
   tests:
   - from: /vfb/2016-01-21/fbbt_vfb_ind.owl
     to: https://raw.githubusercontent.com/VirtualFlyBrain/VFB_owl/Archive/src/owl/2016-01-21/fbbt_vfb_ind.owl.gz
 
-- exact: /vfb/(20.*)/vfb.owl
+- regex: ^/vfb/(20.*)/vfb.owl$
   replacement: https://raw.githubusercontent.com/VirtualFlyBrain/VFB_owl/$1/src/owl/vfb.owl.gz
   tests:
   - from: /vfb/2016-07-12/vfb.owl
     to: https://raw.githubusercontent.com/VirtualFlyBrain/VFB_owl/2016-07-12/src/owl/vfb.owl.gz
 
-- exact: /vfb/(20.*)/
+- regex: ^/vfb/(20.*)/$
   replacement: https://raw.githubusercontent.com/VirtualFlyBrain/VFB_owl/$1/src/owl/
   tests:
   - from: /vfb/2016-07-12/

--- a/config/fbbt.yml
+++ b/config/fbbt.yml
@@ -33,6 +33,24 @@ entries:
 - exact: /vfb/vfb.owl
   replacement: http://virtualflybrain.org/owl/vfb.owl
   
+- regex: ^/obo/fbbt/vfb/releases/(.*)/vfb\.owl$
+  replacement: https://raw.githubusercontent.com/VirtualFlyBrain/VFB_owl/$1/src/owl/vfb.owl.gz
+  tests:
+  - from: /vfb/releases/Current/vfb.owl
+    to: https://raw.githubusercontent.com/VirtualFlyBrain/VFB_owl/Current/src/owl/vfb.owl.gz
+    
+- regex: ^/obo/fbbt/vfb/releases/(.*)/fbbt_(.*)\.owl$
+  replacement: https://raw.githubusercontent.com/VirtualFlyBrain/VFB_owl/$1/src/owl/fbbt_$2.owl.gz
+  tests:
+  - from: /vfb/releases/Current/fbbt_vfb_ind.owl
+    to: https://raw.githubusercontent.com/VirtualFlyBrain/VFB_owl/Current/src/owl/fbbt_vfb_ind.owl.gz
+  
+- regex: ^/obo/fbbt/vfb/releases/(.*)/$
+  replacement: https://raw.githubusercontent.com/VirtualFlyBrain/VFB_owl/$1/src/owl/
+  tests:
+  - from: /vfb/releases/Current/
+    to: https://raw.githubusercontent.com/VirtualFlyBrain/VFB_owl/Current/src/owl/
+  
 - regex: ^/obo/fbbt/vfb/(2016-0[0-6]-[0-9][0-9])/vfb\.owl$
   replacement: https://raw.githubusercontent.com/VirtualFlyBrain/VFB_owl/Archive/src/owl/$1/vfb.owl.gz
   tests:

--- a/config/fbbt.yml
+++ b/config/fbbt.yml
@@ -33,19 +33,19 @@ entries:
 - exact: /vfb/vfb.owl
   replacement: http://virtualflybrain.org/owl/vfb.owl
   
-- regex: ^/obo/fbbt/vfb/(2016-0[0-7]-[0-9][0-9])/vfb\.owl$
+- regex: ^/obo/fbbt/vfb/(2016-0[0-6]-[0-9][0-9])/vfb\.owl$
   replacement: https://raw.githubusercontent.com/VirtualFlyBrain/VFB_owl/Archive/src/owl/$1/vfb.owl.gz
   tests:
   - from: /vfb/2016-01-21/vfb.owl
     to: https://raw.githubusercontent.com/VirtualFlyBrain/VFB_owl/Archive/src/owl/2016-01-21/vfb.owl.gz
   
-- regex: ^/obo/fbbt/vfb/(2016-0[0-7]-[0-9][0-9])/fbbt_(.*)\.owl$
+- regex: ^/obo/fbbt/vfb/(2016-0[0-6]-[0-9][0-9])/fbbt_(.*)\.owl$
   replacement: https://raw.githubusercontent.com/VirtualFlyBrain/VFB_owl/Archive/src/owl/$1/fbbt_$2.owl
   tests:
   - from: /vfb/2016-01-21/fbbt_vfb_ind.owl
     to: https://raw.githubusercontent.com/VirtualFlyBrain/VFB_owl/Archive/src/owl/2016-01-21/fbbt_vfb_ind.owl.gz
   
-- regex: ^/obo/fbbt/vfb/(201[5-6]-0[0-7]-[0-9][0-9])/$
+- regex: ^/obo/fbbt/vfb/(201[5-6]-0[0-6]-[0-9][0-9])/$
   replacement: https://raw.githubusercontent.com/VirtualFlyBrain/VFB_owl/Archive/src/owl/$1/
   tests:
   - from: /vfb/2016-01-21/


### PR DESCRIPTION
VFB is moving to github tag/version revisions rather than the folder system previously used.

I've added redirects for historical versions as well as new versions.

Larger ontologies are now being gzipped hence the redirects for specific OWL files.

Requested by @dosumis in https://github.com/VirtualFlyBrain/VFB_owl/issues/29 