### PR TITLE
iao.yml reorg + staging for release 2017-01-06

### DIFF
--- a/config/iao.yml
+++ b/config/iao.yml
@@ -1,87 +1,55 @@
 # PURL configuration for http://purl.obolibrary.org/obo/iao
+# It's easy to have this get disorganized. Please put new entries in appropriate
+# section (IAO, PNO, D-ACTS)/(Current/Examples/Well-known/Dev/Versions)
+# With versions in reverse chronological order (newest on top)
 
 idspace: IAO
 base_url: /obo/iao
 
+# where http://purl.obolibrary.org/obo/iao redirects to:
 base_redirect: https://github.com/information-artifact-ontology/IAO 
 
 products:
+###  STAGING: uncomment when 2017-01-06 is made current, and remove corresponding stale entries here
+###- iao.owl: https://raw.githubusercontent.com/information-artifact-ontology/IAO/master/releases/2017-01-06/iao-merged.owl
 - iao.owl: https://raw.githubusercontent.com/information-artifact-ontology/IAO/master/releases/2015-02-23/iao.owl
 - iao.obo: https://raw.githubusercontent.com/information-artifact-ontology/IAO/master/releases/2009-11-06/merged/iao.obo
 
 term_browser: ontobee
+
 example_terms:
 - IAO_0000030
 
 entries:
-- exact: /2008-11-24/ontology-metadata.owl
-  replacement: https://raw.githubusercontent.com/information-artifact-ontology/IAO/2008-11-24/ontology-metadata.owl
+# IAO Current 
+###  STAGING: uncomment when 2017-01-06 is made current, and remove corresponding stale entries
+### - exact: /iao-stated.owl
+###   replacement: https://raw.githubusercontent.com/information-artifact-ontology/IAO/master/releases/2017-01-06/iao.owl
+### - exact: /ontology-metadata.owl
+###   replacement: https://raw.githubusercontent.com/information-artifact-ontology/IAO/master/releases/2017-01-06/ontology-metadata.owl
+### - exact: /iao-main.owl
+###   replacement: https://raw.githubusercontent.com/information-artifact-ontology/IAO/master/releases/2017-01-06/iao-main.owl
+### - exact: /release-notes
+###   replacement: https://raw.githubusercontent.com/information-artifact-ontology/IAO/master/releases/2017-01-06/release-notes.txt
 
-- exact: /2009-07-15/ontology-metadata.owl
-  replacement: https://raw.githubusercontent.com/information-artifact-ontology/IAO/2009-07-15/ontology-metadata.owl
+- exact: /iao-main.owl
+  replacement: https://raw.githubusercontent.com/information-artifact-ontology/IAO/master/releases/2015-02-23/ontology/iao-main.owl
 
-- exact: /2009-01-23/ontology-metadata.owl
-  replacement: https://raw.githubusercontent.com/information-artifact-ontology/IAO/2009-01-23/ontology-metadata.owl
+- exact: /ontology-metadata.owl
+  replacement: https://raw.githubusercontent.com/information-artifact-ontology/IAO/master/releases/2015-02-23/ontology-metadata.owl
+
+# IAO Examples
+
+- exact: /example/community-label.owl
+  replacement: https://raw.githubusercontent.com/information-artifact-ontology/IAO/master/src/example/community-label.owl
 
 - exact: /dev/examples.owl
   replacement: https://raw.githubusercontent.com/information-artifact-ontology/IAO/master/src/ontology/iao-examples.owl
 
+# IAO Well-known
+
 - exact: /tracker
   replacement: https://github.com/information-artifact-ontology/IAO/issues
-
-- exact: /2009-07-15/obsolete.owl
-  replacement: https://raw.githubusercontent.com/information-artifact-ontology/IAO/2009-07-15/obsolete.owl
-
-- exact: /dev/iao-dev.owl
-  replacement: https://raw.githubusercontent.com/information-artifact-ontology/IAO/master/src/ontology/iao-dev.owl
-
-- exact: /2009-03-17/iao.owl
-  replacement: https://raw.githubusercontent.com/information-artifact-ontology/IAO/2009-03-17/IAO.owl
-
-- exact: /dev/owl2bits.owl
-  replacement: https://raw.githubusercontent.com/information-artifact-ontology/IAO/master/src/ontology/iao-owl2.owl
-
-- exact: /dev/iao.owl
-  replacement: https://raw.githubusercontent.com/information-artifact-ontology/IAO/master/src/ontology/IAO.owl
-
-- exact: /2009-03-17/ontology-metadata.owl
-  replacement: https://raw.githubusercontent.com/information-artifact-ontology/IAO/2009-03-17/ontology-metadata.owl
-
-- exact: /dev/obsolete.owl
-  replacement: https://raw.githubusercontent.com/information-artifact-ontology/IAO/master/src/ontology/obsolete.owl
-
-- exact: /dev/ontology-metadata.owl
-  replacement: https://raw.githubusercontent.com/information-artifact-ontology/IAO/master/src/ontology/ontology-metadata.owl
-
-- exact: /2009-07-15/iao/iao.owl
-  replacement: https://raw.githubusercontent.com/information-artifact-ontology/IAO/2009-07-15/IAO.owl
-
-- exact: /2008-11-24/iao.owl
-  replacement: https://raw.githubusercontent.com/information-artifact-ontology/IAO/2008-11-24/iao.owl
-
-- exact: /2009-07-15/iao.owl
-  replacement: https://raw.githubusercontent.com/information-artifact-ontology/IAO/2009-07-15/IAO.owl
-
-- exact: /2009-01-23/iao.owl
-  replacement: https://raw.githubusercontent.com/information-artifact-ontology/IAO/2009-01-23/iao.owl
-
-- exact: /dev/external.owl
-  replacement: https://raw.githubusercontent.com/information-artifact-ontology/IAO/master/src/ontology/external.owl
-
-- exact: /dev/externalDerived.owl
-  replacement: https://raw.githubusercontent.com/information-artifact-ontology/IAO/master/src/ontology/externalDerived.owl
-
-- exact: /dev/iao-main.owl
-  replacement: https://raw.githubusercontent.com/information-artifact-ontology/IAO/master/src/ontology/iao-main.owl
-
-- exact: /obsolete.owl
-  replacement: https://raw.githubusercontent.com/information-artifact-ontology/IAO/master/releases/2009-11-06/merged/obsolete.owl
-
-- exact: /dev/externalByHand.owl
-  replacement: https://raw.githubusercontent.com/information-artifact-ontology/IAO/master/src/ontology/externalByHand.owl
-
-- exact: /example/community-label.owl
-  replacement: https://raw.githubusercontent.com/information-artifact-ontology/IAO/master/src/example/community-label.owl
 
 - exact: /reports
   replacement: https://github.com/information-artifact-ontology/IAO/tree/master/docs
@@ -91,6 +59,47 @@ entries:
 
 - exact: /repository
   replacement: https://github.com/information-artifact-ontology/IAO
+
+- prefix: /about/
+  replacement: http://www.ontobee.org/browser/rdf.php?o=IAO&iri=http://purl.obolibrary.org/obo/
+
+# IAO Dev
+
+- prefix: /dev/
+  replacement: https://raw.githubusercontent.com/information-artifact-ontology/IAO/master/src/ontology/
+
+# IAO Versions
+
+# 2017-01-06
+
+- exact: /2017-01-06/iao.owl
+  replacement: https://raw.githubusercontent.com/information-artifact-ontology/IAO/master/releases/2017-01-06/iao-merged.owl
+
+- exact: /2017-01-06/iao-stated.owl
+  replacement: https://raw.githubusercontent.com/information-artifact-ontology/IAO/master/releases/2017-01-06/iao.owl
+
+- prefix: /2017-01-06/ 
+  replacement: https://raw.githubusercontent.com/information-artifact-ontology/IAO/master/releases/2017-01-06/
+
+# 2015-02-23
+
+- exact: /2015-02-23/iao.owl
+  replacement: https://raw.githubusercontent.com/information-artifact-ontology/IAO/master/releases/2015-02-23/iao.owl
+
+- exact: /2015-02-23/ontology-metadata.owl
+  replacement: https://raw.githubusercontent.com/information-artifact-ontology/IAO/master/releases/2015-02-23/ontology-metadata.owl
+
+- prefix: /bfo2-transitional/
+  replacement: https://raw.githubusercontent.com/information-artifact-ontology/IAO/tree/2014-06-13/ontology/
+
+- exact: /bfo-transitional/notes
+  replacement: https://docs.google.com/document/d/1CRLrqYyq9s2xaf3zT0mae190ZFDTWJnflgLEtY2Rf8g/edit?usp=sharing
+
+- exact: /2012-01-05/ontology-metadata.owl
+  replacement: https://raw.githubusercontent.com/information-artifact-ontology/IAO/master/releases/2012-01-05/merged/ontology-metadata.owl
+
+- exact: /2012-01-05/iao-main.owl
+  replacement: https://raw.githubusercontent.com/information-artifact-ontology/IAO/master/releases/2012-01-05/merged/iao-main.owl
 
 - exact: /2011-08-04/obsolete.owl
   replacement: https://raw.githubusercontent.com/information-artifact-ontology/IAO/master/releases/2011-08-04/merged/obsolete.owl
@@ -104,41 +113,116 @@ entries:
 - exact: /2011-08-04/iao.owl
   replacement: https://raw.githubusercontent.com/information-artifact-ontology/IAO/master/releases/2011-08-04/merged/iao.owl
 
-- exact: /2012-01-05/ontology-metadata.owl
-  replacement: https://raw.githubusercontent.com/information-artifact-ontology/IAO/master/releases/2012-01-05/merged/ontology-metadata.owl
+- prefix: /2011-05-19/
+  replacement: https://raw.githubusercontent.com/information-artifact-ontology/IAO/master/releases/2011-05-09/
 
-- exact: /2012-01-05/iao-main.owl
-  replacement: https://raw.githubusercontent.com/information-artifact-ontology/IAO/master/releases/2012-01-05/merged/iao-main.owl
+- prefix: /2011-05-09/
+  replacement: https://raw.githubusercontent.com/information-artifact-ontology/IAO/master/releases/2011-05-09/
 
-- exact: /iao-main.owl
-  replacement: https://raw.githubusercontent.com/information-artifact-ontology/IAO/master/releases/2015-02-23/ontology/iao-main.owl
+- prefix: /2010-10-26/
+  replacement: https://raw.githubusercontent.com/information-artifact-ontology/IAO/master/releases/2010-10-26/
 
-- exact: /bfo-transitional/notes
-  replacement: https://docs.google.com/document/d/1CRLrqYyq9s2xaf3zT0mae190ZFDTWJnflgLEtY2Rf8g/edit?usp=sharing
+- prefix: /2010-09-14/
+  replacement: https://raw.githubusercontent.com/information-artifact-ontology/IAO/master/releases/2010-09-14/
 
-- exact: /bfo2-transitional/notes
-  replacement: https://docs.google.com/document/d/1CRLrqYyq9s2xaf3zT0mae190ZFDTWJnflgLEtY2Rf8g/edit?usp=sharing
+- prefix: /2009-11-06/
+  replacement: https://raw.githubusercontent.com/information-artifact-ontology/IAO/master/releases/2009-11-06/merged/
 
-- exact: /2015-02-23/iao.owl
-  replacement: https://raw.githubusercontent.com/information-artifact-ontology/IAO/master/releases/2015-02-23/iao.owl
+- prefix: /2009-11-02/
+  replacement: https://raw.githubusercontent.com/information-artifact-ontology/IAO/master/releases/2009-11-02/merged/
 
-- exact: /ontology-metadata.owl
-  replacement: https://raw.githubusercontent.com/information-artifact-ontology/IAO/master/releases/2015-02-23/ontology-metadata.owl
+- exact: /2009-07-15/ontology-metadata.owl
+  replacement: https://raw.githubusercontent.com/information-artifact-ontology/IAO/2009-07-15/ontology-metadata.owl
 
-- exact: /2015-02-23/ontology-metadata.owl
-  replacement: https://raw.githubusercontent.com/information-artifact-ontology/IAO/master/releases/2015-02-23/ontology-metadata.owl
+- exact: /2009-07-15/obsolete.owl
+  replacement: https://raw.githubusercontent.com/information-artifact-ontology/IAO/2009-07-15/obsolete.owl
+
+- exact: /2009-07-15/iao/iao.owl
+  replacement: https://raw.githubusercontent.com/information-artifact-ontology/IAO/2009-07-15/IAO.owl
+
+- exact: /2009-03-17/iao.owl
+  replacement: https://raw.githubusercontent.com/information-artifact-ontology/IAO/2009-03-17/IAO.owl
+
+- exact: /2009-03-17/ontology-metadata.owl
+  replacement: https://raw.githubusercontent.com/information-artifact-ontology/IAO/2009-03-17/ontology-metadata.owl
+
+- exact: /2009-07-15/iao.owl
+  replacement: https://raw.githubusercontent.com/information-artifact-ontology/IAO/2009-07-15/IAO.owl
+
+- exact: /2009-01-23/iao.owl
+  replacement: https://raw.githubusercontent.com/information-artifact-ontology/IAO/2009-01-23/iao.owl
+
+- exact: /2009-01-23/ontology-metadata.owl
+  replacement: https://raw.githubusercontent.com/information-artifact-ontology/IAO/2009-01-23/ontology-metadata.owl
+
+- exact: /2008-11-24/iao.owl
+  replacement: https://raw.githubusercontent.com/information-artifact-ontology/IAO/2008-11-24/iao.owl
+
+- exact: /2008-11-24/ontology-metadata.owl
+  replacement: https://raw.githubusercontent.com/information-artifact-ontology/IAO/2008-11-24/ontology-metadata.owl
+
+# Proper name ontology(PNO) current
+
+- exact: /pno.owl
+  replacement: https://raw.githubusercontent.com/ProperNameOntology/proper-name-ontology/master/pno.owl
+
+# PNO dev
+
+- exact: /pno/dev/pno.owl
+  replacement: https://raw.githubusercontent.com/ProperNameOntology/proper-name-ontology/master/development/pno.owl
+
+# PNO versions
+
+- exact: /pno/2014-05-03/pno.owl
+  replacement: https://raw.githubusercontent.com/ProperNameOntology/proper-name-ontology/2014-03-05/pno.owl
+
+- exact: /pno/bfo2/pno.owl
+  replacement: https://raw.githubusercontent.com/ProperNameOntology/proper-name-ontology/bfo2/pno.owl
+
+- prefix: /pno/release/
+  replacement: https://raw.githubusercontent.com/ProperNameOntology/proper-name-ontology/
+
+# Document Acts(D-ACTS) current
+
+- exact: /d-acts.owl
+  replacement: https://raw.githubusercontent.com/d-acts/d-acts/master/d-acts.owl
+
+# D-ACTS dev
+
+- exact: /d-acts/dev/d-acts.owl
+  replacement: https://raw.githubusercontent.com/d-acts/d-acts/master/development/d-acts.owl
+
+# D-ACTS versions
 
 - exact: /d-acts/2016-06-22/d-acts.owl
   replacement: https://raw.githubusercontent.com/d-acts/d-acts/2016-06-22/releases/d-acts.owl
   
+- exact: /d-acts/2016-04-22/d-acts.owl
+  replacement: https://raw.githubusercontent.com/d-acts/d-acts/2016-04-22/d-acts.owl
+
+- exact: /d-acts/20160407/d-acts.owl
+  replacement: https://raw.githubusercontent.com/d-acts/d-acts/2016-04-07/d-acts.owl
+  
+- exact: /d-acts/2016-02-16/d-acts.owl
+  replacement: https://raw.githubusercontent.com/d-acts/d-acts/2016-04-22/d-acts.owl
+  
+- exact: /d-acts/20150916/d-acts.owl
+  replacement: https://raw.githubusercontent.com/d-acts/d-acts/master/releases/20150916/d-acts.owl
+
+- exact: /d-acts/20150915/d-acts.owl
+  replacement: https://raw.githubusercontent.com/d-acts/d-acts/master/releases/20150915/d-acts.owl
+  
+- exact: /d-acts/20151202/d-acts.owl
+  replacement: https://raw.githubusercontent.com/d-acts/d-acts/2015-12-02/d-acts.owl
+
+- exact: /d-acts/2013-11-27-d-acts.owl
+  replacement: https://raw.githubusercontent.com/d-acts/d-acts/2013-11-27/d-acts.owl
+
 - exact: /d-acts/2013-06-28/d-acts.owl
   replacement: https://raw.githubusercontent.com/d-acts/d-acts/2013-06-28/d-acts.owl
 
 - exact: /d-acts/2012-1102/d-acts.owl
   replacement: https://raw.githubusercontent.com/d-acts/d-acts/2012-11-02/d-acts.owl
-
-- exact: /d-acts/2012-07-02-11/d-acts.owl
-  replacement: https://raw.githubusercontent.com/d-acts/d-acts/2012-07-11/d-acts.owl
 
 - exact: /d-acts/2012-11-02/d-acts.owl
   replacement: https://raw.githubusercontent.com/d-acts/d-acts/2012-11-02/d-acts.owl
@@ -149,83 +233,16 @@ entries:
 - exact: /d-acts/2012-07-03/d-acts.owl
   replacement: https://raw.githubusercontent.com/d-acts/d-acts/2012-07-03/d-acts.owl
 
-- exact: /d-acts/2013-11-27-d-acts.owl
-  replacement: https://raw.githubusercontent.com/d-acts/d-acts/2013-11-27/d-acts.owl
-
-- exact: /d-acts/2013-11-27/d-acts.owl
-  replacement: https://raw.githubusercontent.com/d-acts/d-acts/2013-11-27/d-acts.owl
-  
-- exact: /d-acts/2016-02-16/d-acts.owl
-  replacement: https://raw.githubusercontent.com/d-acts/d-acts/2016-04-22/d-acts.owl
-  
-- exact: /d-acts/2016-04-22/d-acts.owl
-  replacement: https://raw.githubusercontent.com/d-acts/d-acts/2016-04-22/d-acts.owl
-
-- exact: /pno/2014-05-03/pno.owl
-  replacement: https://raw.githubusercontent.com/ProperNameOntology/proper-name-ontology/2014-03-05/pno.owl
-
-- exact: /pno/bfo2/pno.owl
-  replacement: https://raw.githubusercontent.com/ProperNameOntology/proper-name-ontology/bfo2/pno.owl
-
-- exact: /pno.owl
-  replacement: https://raw.githubusercontent.com/ProperNameOntology/proper-name-ontology/master/pno.owl
-
-- exact: /pno/dev/pno.owl
-  replacement: https://raw.githubusercontent.com/ProperNameOntology/proper-name-ontology/master/development/pno.owl
-
-- prefix: /pno/release/
-  replacement: https://raw.githubusercontent.com/ProperNameOntology/proper-name-ontology/
+- exact: /d-acts/2012-07-02-11/d-acts.owl
+  replacement: https://raw.githubusercontent.com/d-acts/d-acts/2012-07-11/d-acts.owl
 
 - exact: /d-acts/legacy/d-acts.owl
   replacement: https://raw.githubusercontent.com/d-acts/d-acts/master/d-acts_legacy.owl
-
-- exact: /d-acts/dev/d-acts.owl
-  replacement: https://raw.githubusercontent.com/d-acts/d-acts/master/development/d-acts.owl
-
-- exact: /d-acts.owl
-  replacement: https://raw.githubusercontent.com/d-acts/d-acts/master/d-acts.owl
   
 - prefix: /d-acts/release/
   replacement: https://raw.githubusercontent.com/d-acts/d-acts/
 
-- exact: /d-acts/20150916/d-acts.owl
-  replacement: https://raw.githubusercontent.com/d-acts/d-acts/master/releases/20150916/d-acts.owl
-
-- exact: /d-acts/20150915/d-acts.owl
-  replacement: https://raw.githubusercontent.com/d-acts/d-acts/master/releases/20150915/d-acts.owl
-  
-- exact: /d-acts/20160407/d-acts.owl
-  replacement: https://raw.githubusercontent.com/d-acts/d-acts/2016-04-07/d-acts.owl
-  
-- exact: /d-acts/20151202/d-acts.owl
-  replacement: https://raw.githubusercontent.com/d-acts/d-acts/2015-12-02/d-acts.owl
-
-- prefix: /bfo2-transitional/
-  replacement: https://raw.githubusercontent.com/information-artifact-ontology/IAO/tree/2014-06-13/ontology/
-
-- prefix: /2009-11-02/
-  replacement: https://raw.githubusercontent.com/information-artifact-ontology/IAO/master/releases/2009-11-02/merged/
-
-- prefix: /2009-11-06/
-  replacement: https://raw.githubusercontent.com/information-artifact-ontology/IAO/master/releases/2009-11-06/merged/
-
-- prefix: /2010-09-14/
-  replacement: https://raw.githubusercontent.com/information-artifact-ontology/IAO/master/releases/2010-09-14/
-
-- prefix: /2010-10-26/
-  replacement: https://raw.githubusercontent.com/information-artifact-ontology/IAO/master/releases/2010-10-26/
-
-- prefix: /2011-05-19/
-  replacement: https://raw.githubusercontent.com/information-artifact-ontology/IAO/master/releases/2011-05-09/
-
-- prefix: /2011-05-09/
-  replacement: https://raw.githubusercontent.com/information-artifact-ontology/IAO/master/releases/2011-05-09/
-
-- prefix: /about/
-  replacement: http://www.ontobee.org/browser/rdf.php?o=IAO&iri=http://purl.obolibrary.org/obo/
-  tests:
+# Tests
+tests:
   - from: /about/IAO_0000030
     to: http://www.ontobee.org/browser/rdf.php?o=IAO&iri=http://purl.obolibrary.org/obo/IAO_0000030
-
-- prefix: /dev/
-  replacement: https://raw.githubusercontent.com/information-artifact-ontology/IAO/master/src/ontology/


### PR DESCRIPTION
staging for IAO release. dated purls in place. current purls commented out until get ok from mailing list
File was reorganized. Comments on how to maintain at the top.  Release notes at https://raw.githubusercontent.com/information-artifact-ontology/IAO/master/releases/2017-01-06/release-notes.txt