### PR TITLE
Adjust DUO releases, fixes #296

### DIFF
--- a/config/duo.yml
+++ b/config/duo.yml
@@ -14,7 +14,7 @@ example_terms:
 entries:
 
 - prefix: /releases/
-  replacement: https://raw.githubusercontent.com/EBISPOT/DUO/releases/v
+  replacement: https://raw.githubusercontent.com/EBISPOT/DUO/v
 
 - prefix: /tracker/
   replacement: https://github.com/EBISPOT/DUO/issues


### PR DESCRIPTION
This should redirect <http://purl.obolibrary.org/obo/duo/releases/2017-01-31/duo.owl> to <https://github.com/EBISPOT/DUO/blob/v2017-01-31/duo.owl>.