### PR TITLE
Switching mp.owl to use central OBO server

### DIFF
--- a/config/mp.yml
+++ b/config/mp.yml
@@ -4,7 +4,7 @@ idspace: MP
 base_url: /obo/mp
 
 products:
-- mp.owl: ftp://ftp.informatics.jax.org/pub/reports/mp.owl
+- mp.owl: http://ontologies.berkeleybop.org/mp.owl
 - mp.obo: http://ontologies.berkeleybop.org/mp.obo
 
 term_browser: ontobee


### PR DESCRIPTION
JAX ftp no longer supported. Switching to using the central OBO server til we investigate (this will be at most one day behind JAX, and has the advantage of being served via cloudfront)