### PR TITLE
Routing CHEBI purls directly to EBI to avoid dependency on central OB…

### DIFF
--- a/config/chebi.yml
+++ b/config/chebi.yml
@@ -4,8 +4,10 @@ idspace: CHEBI
 base_url: /obo/chebi
 
 products:
-- chebi.owl: http://ontologies.berkeleybop.org/chebi.owl
-- chebi.obo: http://ontologies.berkeleybop.org/chebi.obo
+- chebi.owl: ftp://ftp.ebi.ac.uk/pub/databases/chebi/ontology/chebi.owl
+- chebi.obo: ftp://ftp.ebi.ac.uk/pub/databases/chebi/ontology/chebi.obo
+- chebi.owl.gz: ftp://ftp.ebi.ac.uk/pub/databases/chebi/ontology/chebi.owl.gz
+- chebi.obo.gz: ftp://ftp.ebi.ac.uk/pub/databases/chebi/ontology/chebi.obo.gz
 
 term_browser: custom
 


### PR DESCRIPTION
…O build

Historically we have built chebi centrally due to this
https://github.com/ebi-chebi/ChEBI/issues/3202

But this issue is now resolved.

Note I'm also introducing two new top-levels (maybe should this on new PR?). We don't have rules on new top-levels, but I assume $ONT.SUFFIX is allowed for reasonable suffixes within $ONT. CHEBI provide gzips which is something I think we should encourage -- although it's fiddly with imports. See: https://github.com/owlcs/owlapi/issues/375