### PR TITLE
Fixing typo xap->xao

### DIFF
--- a/config/xao.yml
+++ b/config/xao.yml
@@ -4,8 +4,8 @@ idspace: XAO
 base_url: /obo/xao
 
 products:
-- xap.owl: http://ontologies.berkeleybop.org/xao.owl
-- xap.obo: http://ontologies.berkeleybop.org/xao.obo
+- xao.owl: http://ontologies.berkeleybop.org/xao.owl
+- xao.obo: http://ontologies.berkeleybop.org/xao.obo
 
 term_browser: ontobee
 example_terms:


### PR DESCRIPTION
Fixing typo see https://github.com/OBOFoundry/OBOFoundry.github.io/issues/395