### PR TITLE
Update hp.yml

### DIFF
--- a/config/hp.yml
+++ b/config/hp.yml
@@ -3,9 +3,11 @@
 idspace: HP
 base_url: /obo/hp
 
+base_redirect: https://github.com/obophenotype/human-phenotype-ontology
+
 products:
-- hp.owl: https://compbio.charite.de/jenkins/job/hpo/lastStableBuild/artifact/hp/hp.owl
-- hp.obo: https://compbio.charite.de/jenkins/job/hpo/lastStableBuild/artifact/hp/hp.obo
+- hp.owl: https://raw.githubusercontent.com/obophenotype/human-phenotype-ontology/master/hp.owl
+- hp.obo: https://raw.githubusercontent.com/obophenotype/human-phenotype-ontology/master/hp.obo
 
 term_browser: ontobee
 example_terms:
@@ -16,7 +18,7 @@ entries:
   replacement: http://compbio.charite.de/hudson/job/hpo.ontology.uberpheno/lastStableBuild/artifact/data/uberphenoOut/
 
 - prefix: /releases/
-  replacement: https://compbio.charite.de/svn/hpo/releases/
+  replacement: https://raw.githubusercontent.com/obophenotype/human-phenotype-ontology/v
 
 - prefix: /tracker
   replacement: https://github.com/obophenotype/human-phenotype-ontology/issues


### PR DESCRIPTION
We switch from our Jenkins server to GH releases. Motivation for this are:

- https://github.com/obophenotype/human-phenotype-ontology/issues/742#issuecomment-285213129
- https://github.com/monarch-initiative/monarch-owlsim-data/commit/7ac3a50418007076d20f4aa61165fcd55bb40d72#commitcomment-21219160

I took pato.yml as template and changed hp.yml accordingly.

@cmungall does this look good?