### PR TITLE
adding core, fixing imports path

### DIFF
--- a/config/foodon.yml
+++ b/config/foodon.yml
@@ -7,6 +7,7 @@ base_url: /obo/foodon
 products:
 - foodon.owl: https://raw.githubusercontent.com/FoodOntology/foodon/master/foodon.owl
 - foodon_core.owl: https://raw.githubusercontent.com/FoodOntology/foodon/master/foodon_core.owl
+- foodon.obo: https://raw.githubusercontent.com/FoodOntology/foodon/master/foodon_old.obo
 
 term_browser: ontobee
 example_terms:

--- a/config/foodon.yml
+++ b/config/foodon.yml
@@ -6,7 +6,7 @@ base_url: /obo/foodon
 
 products:
 - foodon.owl: https://raw.githubusercontent.com/FoodOntology/foodon/master/foodon.owl
-- foodon.obo: https://raw.githubusercontent.com/FoodOntology/foodon/master/foodon.obo
+- foodon_core.owl: https://raw.githubusercontent.com/FoodOntology/foodon/master/foodon_core.owl
 
 term_browser: ontobee
 example_terms:
@@ -14,4 +14,5 @@ example_terms:
 
 entries:
 - prefix: /imports/
-  replacement: https://raw.githubusercontent.com/FoodOntology/foodon/master/src/imports/
+  replacement: https://raw.githubusercontent.com/FoodOntology/foodon/master/imports/
+  


### PR DESCRIPTION
Currently the /imports/ folder path is wrong, causing it to fail to load in OLS and others.  This fixes.  As well, ontology now has a foodon_core.owl file.