### PR TITLE
Added a snapshot PURL for GO

### DIFF
--- a/config/go.yml
+++ b/config/go.yml
@@ -35,6 +35,9 @@ entries:
 - prefix: /releases/
   replacement: http://viewvc.geneontology.org/viewvc/GO-SVN/ontology-releases/
 
+- prefix: /snapshot/
+  replacement: http://snapshot.geneontology.org/ontology/
+
 - prefix: /about/
   replacement: http://www.ontobee.org/browser/rdf.php?o=GO&iri=http://purl.obolibrary.org/obo/
 


### PR DESCRIPTION
Redirecting PURLs of the form /obo/go/snapshot/... to cloudfront, served from http://snapshot.geneontology.org
https://github.com/geneontology/go-site/issues/209