### PR TITLE
Update po config to include planteome.owl

### DIFF
--- a/config/po.yml
+++ b/config/po.yml
@@ -8,6 +8,8 @@ products:
 - po.obo: https://raw.githubusercontent.com/Planteome/plant-ontology/master/po.obo
 
 entries:
+- exact: /planteome.owl
+  replacement: https://raw.githubusercontent.com/Planteome/planteome-core/master/planteome.owl
 - prefix: /subsets/
   replacement: https://raw.githubusercontent.com/Planteome/plant-ontology/master/subsets/
 - prefix: /imports/


### PR DESCRIPTION
planteome.owl is an importer ontology for the Planteomeproject, covering all plants.

The proposal is to use this PURL
http://purl.obolibrary.org/obo/po/planteome.owl

Underneath the 'po' plant anatomy reference ontology (even though planteome is more than anatomy, this seems a reasonable place for this)

See: https://github.com/OBOFoundry/OBOFoundry.github.io/issues/405

Fixes https://github.com/Planteome/planteome-core/issues/25