### PR TITLE
Added YML for MPIO

### DIFF
--- a/config/mpio.yml
+++ b/config/mpio.yml
@@ -1,0 +1,18 @@
+# PURL configuration for http://purl.obolibrary.org/obo/mpio
+
+idspace: MPIO
+base_url: /obo/mpio
+
+products:
+- mpio.owl: https://raw.githubusercontent.com/MPIO-Developers/MPIO/master/mpio.owl
+
+term_browser: ontobee
+example_terms:
+- MPIO_0000007
+
+entries:
+- prefix: /release/
+  replacement: https://raw.githubusercontent.com/MPIO-Developers/MPIO/
+  
+- exact: /dev/mpio.owl
+  replacement: https://raw.githubusercontent.com/MPIO-Developers/MPIO/master/development/mpio.owl


### PR DESCRIPTION
The MPIO repository is set up the same way as others we maintain and this configuration supports our release tagging method.

Thanks,
Joseph