### PR TITLE
Update pr.yml

### DIFF
--- a/config/pr.yml
+++ b/config/pr.yml
@@ -24,7 +24,7 @@ entries:
   - from: /9.0/pr.obo
     to: https://research.bioinformatics.udel.edu/PRO/data/release_9.0/pro_nonreasoned.obo
 - regex: (?i)^/obo/pr/([123]\d\.\d+)\.?/pr.obo$
-  replacement: https://research.bioinformatics.udel.edu/PRO/data/release_$1/pro_non_reasoned.obo
+  replacement: https://research.bioinformatics.udel.edu/PRO/data/release_$1/pro_nonreasoned.obo
   tests:
   - from: /22.0/pr.obo
     to: https://research.bioinformatics.udel.edu/PRO/data/release_22.0/pro_nonreasoned.obo
@@ -93,9 +93,9 @@ entries:
   replacement: https://research.bioinformatics.udel.edu/PRO/data/release_$1/pro_nonreasoned.obo
   tests:
   - from: /51.0/pr-asserted.obo
-    to: ftp://ftp.proconsortium.org/databases/ontology/pro_obo/old_files/release_51.0/pro_nonreasoned.obo
+    to: https://research.bioinformatics.udel.edu/PRO/data/release_51.0/pro_nonreasoned.obo
   - from: /51.0./pr-asserted.obo
-    to: ftp://ftp.proconsortium.org/databases/ontology/pro_obo/old_files/release_51.0/pro_nonreasoned.obo
+    to: https://research.bioinformatics.udel.edu/PRO/data/release_51.0/pro_nonreasoned.obo
 
 - regex: (?i)^/obo/pr/(4[3456789]\.\d+)\.?/pr-asserted.owl$
   replacement: ftp://ftp.proconsortium.org/databases/ontology/pro_obo/old_files/release_$1/pro_nonreasoned.owl

--- a/config/pr.yml
+++ b/config/pr.yml
@@ -7,56 +7,111 @@ base_url: /obo/pr
 base_redirect: http://proconsortium.org
 
 products:
-- pr.owl: ftp://ftp.proconsortium.org/databases/ontology/pro_obo/pro_reasoned.owl
-- pr.obo: ftp://ftp.proconsortium.org/databases/ontology/pro_obo/pro_reasoned.obo
-- pr-asserted.owl: ftp://ftp.proconsortium.org/databases/ontology/pro_obo/pro_nonreasoned.owl
-- pr-asserted.obo: ftp://ftp.proconsortium.org/databases/ontology/pro_obo/pro_nonreasoned.obo
+- pr.owl: https://research.bioinformatics.udel.edu/PRO/data/current/pro_reasoned.owl
+- pr.obo: https://research.bioinformatics.udel.edu/PRO/data/current/pro_reasoned.obo
+- pr-asserted.owl: https://research.bioinformatics.udel.edu/PRO/data/current/pro_nonreasoned.owl
+- pr-asserted.obo: https://research.bioinformatics.udel.edu/PRO/data/current/pro_nonreasoned.obo
 
 term_browser: custom
 
 entries:
-- regex: (?i)^/obo/pr/release/(\d+\.\d+)\.?/pr.obo$
-  replacement: ftp://ftp.proconsortium.org/databases/ontology/pro_obo/old_files/release_$1/pro_reasoned.obo
+##### PURLs using major.minor style to indicate the release #####
+# major release is prior to release 43.0; no reasoned version produced so default to non-reasoned; no OWL produced
+
+- regex: (?i)^/obo/pr/(\d\.\d)\.?/pr.obo$
+  replacement: https://research.bioinformatics.udel.edu/PRO/data/release_$1/pro_nonreasoned.obo
   tests:
-  - from: /release/51.0/pr.obo
-    to: ftp://ftp.proconsortium.org/databases/ontology/pro_obo/old_files/release_51.0/pro_reasoned.obo
-  - from: /release/51.0./pr.obo
-    to: ftp://ftp.proconsortium.org/databases/ontology/pro_obo/old_files/release_51.0/pro_reasoned.obo
-- regex: (?i)^/obo/pr/release/(\d+\.\d+)\.?/pr.owl$
-  replacement: ftp://ftp.proconsortium.org/databases/ontology/pro_obo/old_files/release_$1/pro_reasoned.owl
+  - from: /9.0/pr.obo
+    to: https://research.bioinformatics.udel.edu/PRO/data/release_9.0/pro_nonreasoned.obo
+- regex: (?i)^/obo/pr/([123]\d\.\d+)\.?/pr.obo$
+  replacement: https://research.bioinformatics.udel.edu/PRO/data/release_$1/pro_non_reasoned.obo
   tests:
-  - from: /release/51.0/pr.owl
-    to: ftp://ftp.proconsortium.org/databases/ontology/pro_obo/old_files/release_51.0/pro_reasoned.owl
-  - from: /release/51.0./pr.owl
-    to: ftp://ftp.proconsortium.org/databases/ontology/pro_obo/old_files/release_51.0/pro_reasoned.owl
-- regex: (?i)^/obo/pr/(\d+\.\d+)\.?/pr.obo$
-  replacement: ftp://ftp.proconsortium.org/databases/ontology/pro_obo/old_files/release_$1/pro_reasoned.obo
+  - from: /22.0/pr.obo
+    to: https://research.bioinformatics.udel.edu/PRO/data/release_22.0/pro_nonreasoned.obo
+- regex: (?i)^/obo/pr/(4[012]\.\d+)\.?/pr.obo$
+  replacement: https://research.bioinformatics.udel.edu/PRO/data/release_$1/pro_nonreasoned.obo
+  tests:
+  - from: /42.0/pr.obo
+    to: https://research.bioinformatics.udel.edu/PRO/data/release_42.0/pro_nonreasoned.obo
+
+- regex: (?i)^/obo/pr/(\d\.\d)\.?/pr-asserted.obo$
+  replacement: https://research.bioinformatics.udel.edu/PRO/data/release_$1/pro_nonreasoned.obo
+  tests:
+  - from: /9.0/pr-asserted.obo
+    to: https://research.bioinformatics.udel.edu/PRO/data/release_9.0/pro_nonreasoned.obo
+- regex: (?i)^/obo/pr/([123]\d\.\d+)\.?/pr-asserted.obo$
+  replacement: https://research.bioinformatics.udel.edu/PRO/data/release_$1/pro_nonreasoned.obo
+  tests:
+  - from: /22.0/pr-asserted.obo
+    to: https://research.bioinformatics.udel.edu/PRO/data/release_22.0/pro_nonreasoned.obo
+- regex: (?i)^/obo/pr/(4[012]\.\d+)\.?/pr-asserted.obo$
+  replacement: https://research.bioinformatics.udel.edu/PRO/data/release_$1/pro_nonreasoned.obo
+  tests:
+  - from: /42.0/pr-asserted.obo
+    to: https://research.bioinformatics.udel.edu/PRO/data/release_42.0/pro_nonreasoned.obo
+
+# major release is release 43.0 or after; reasoned version of both OBO and OWL produced
+
+- regex: (?i)^/obo/pr/(4[3456789]\.\d+)\.?/pr.obo$
+  replacement: https://research.bioinformatics.udel.edu/PRO/data/release_$1/pro_reasoned.obo
+  tests:
+  - from: /45.0/pr.obo
+    to: https://research.bioinformatics.udel.edu/PRO/data/release_45.0/pro_reasoned.obo
+  - from: /45.0./pr.obo
+    to: https://research.bioinformatics.udel.edu/PRO/data/release_45.0/pro_reasoned.obo
+- regex: (?i)^/obo/pr/([56789]\d+\.\d+)\.?/pr.obo$
+  replacement: https://research.bioinformatics.udel.edu/PRO/data/release_$1/pro_reasoned.obo
   tests:
   - from: /51.0/pr.obo
-    to: ftp://ftp.proconsortium.org/databases/ontology/pro_obo/old_files/release_51.0/pro_reasoned.obo
+    to: https://research.bioinformatics.udel.edu/PRO/data/release_51.0/pro_reasoned.obo
   - from: /51.0./pr.obo
-    to: ftp://ftp.proconsortium.org/databases/ontology/pro_obo/old_files/release_51.0/pro_reasoned.obo
-- regex: (?i)^/obo/pr/(\d+\.\d+)\.?/pr.owl$
-  replacement: ftp://ftp.proconsortium.org/databases/ontology/pro_obo/old_files/release_$1/pro_reasoned.owl
+    to: https://research.bioinformatics.udel.edu/PRO/data/release_51.0/pro_reasoned.obo
+
+- regex: (?i)^/obo/pr/(4[3456789]\.\d+)\.?/pr.owl$
+  replacement: https://research.bioinformatics.udel.edu/PRO/data/release_$1/pro_reasoned.owl
+  tests:
+  - from: /45.0/pr.owl
+    to: https://research.bioinformatics.udel.edu/PRO/data/release_45.0/pro_reasoned.owl
+  - from: /45.0./pr.owl
+    to: https://research.bioinformatics.udel.edu/PRO/data/release_45.0/pro_reasoned.owl
+- regex: (?i)^/obo/pr/([56789]\d+\.\d+)\.?/pr.owl$
+  replacement: https://research.bioinformatics.udel.edu/PRO/data/release_$1/pro_reasoned.owl
   tests:
   - from: /51.0/pr.owl
-    to: ftp://ftp.proconsortium.org/databases/ontology/pro_obo/old_files/release_51.0/pro_reasoned.owl
+    to: https://research.bioinformatics.udel.edu/PRO/data/release_51.0/pro_reasoned.owl
   - from: /51.0./pr.owl
-    to: ftp://ftp.proconsortium.org/databases/ontology/pro_obo/old_files/release_51.0/pro_reasoned.owl
-- regex: (?i)^/obo/pr/(\d+\.\d+)\.?/pr-asserted.obo$
-  replacement: ftp://ftp.proconsortium.org/databases/ontology/pro_obo/old_files/release_$1/pro_nonreasoned.obo
+    to: https://research.bioinformatics.udel.edu/PRO/data/release_51.0/pro_reasoned.owl
+
+- regex: (?i)^/obo/pr/(4[3456789]\.\d+)\.?/pr-asserted.obo$
+  replacement: https://research.bioinformatics.udel.edu/PRO/data/release_$1/pro_nonreasoned.obo
+  tests:
+  - from: /45.0/pr-asserted.obo
+    to: https://research.bioinformatics.udel.edu/PRO/data/release_45.0/pro_nonreasoned.obo
+  - from: /45.0./pr-asserted.obo
+    to: https://research.bioinformatics.udel.edu/PRO/data/release_45.0/pro_nonreasoned.obo
+- regex: (?i)^/obo/pr/([56789]\d+\.\d+)\.?/pr-asserted.obo$
+  replacement: https://research.bioinformatics.udel.edu/PRO/data/release_$1/pro_nonreasoned.obo
   tests:
   - from: /51.0/pr-asserted.obo
     to: ftp://ftp.proconsortium.org/databases/ontology/pro_obo/old_files/release_51.0/pro_nonreasoned.obo
   - from: /51.0./pr-asserted.obo
     to: ftp://ftp.proconsortium.org/databases/ontology/pro_obo/old_files/release_51.0/pro_nonreasoned.obo
-- regex: (?i)^/obo/pr/(\d+\.\d+)\.?/pr-asserted.owl$
+
+- regex: (?i)^/obo/pr/(4[3456789]\.\d+)\.?/pr-asserted.owl$
   replacement: ftp://ftp.proconsortium.org/databases/ontology/pro_obo/old_files/release_$1/pro_nonreasoned.owl
   tests:
+  - from: /45.0/pr-asserted.owl
+    to: ftp://ftp.proconsortium.org/databases/ontology/pro_obo/old_files/release_45.0/pro_nonreasoned.owl
+  - from: /45.0./pr-asserted.owl
+    to: ftp://ftp.proconsortium.org/databases/ontology/pro_obo/old_files/release_45.0/pro_nonreasoned.owl
+- regex: (?i)^/obo/pr/([56789]\d+\.\d+)\.?/pr-asserted.owl$
+  replacement: https://research.bioinformatics.udel.edu/PRO/data/release_$1/pro_nonreasoned.owl
+  tests:
   - from: /51.0/pr-asserted.owl
-    to: ftp://ftp.proconsortium.org/databases/ontology/pro_obo/old_files/release_51.0/pro_nonreasoned.owl
+    to: https://research.bioinformatics.udel.edu/PRO/data/release_51.0/pro_nonreasoned.owl
   - from: /51.0./pr-asserted.owl
-    to: ftp://ftp.proconsortium.org/databases/ontology/pro_obo/old_files/release_51.0/pro_nonreasoned.owl
+    to: https://research.bioinformatics.udel.edu/PRO/data/release_51.0/pro_nonreasoned.owl
+
 # Note that both of the above forms (with and without period after version number) should resolve to the
 #   same file, as the extraneous trailing period stems from an error on the data-version line
 #   in releases prior to 54.0
@@ -70,10 +125,10 @@ entries:
     to: http://research.bioinformatics.udel.edu/pro/entry/PR_000000001
 
 - exact: /pr-asserted.obo
-  replacement: ftp://ftp.proconsortium.org/databases/ontology/pro_obo/pro_nonreasoned.obo
+  replacement: https://research.bioinformatics.udel.edu/PRO/data/current/pro_nonreasoned.obo
   
 - exact: /pr-asserted.owl
-  replacement: ftp://ftp.proconsortium.org/databases/ontology/pro_obo/pro_nonreasoned.owl
+  replacement: https://research.bioinformatics.udel.edu/PRO/data/current/pro_nonreasoned.owl
   
 - exact: /homepage
   replacement: http://proconsortium.org
@@ -97,14 +152,4 @@ entries:
 
 - exact: /pr-dev.obo
   replacement: http://pir.georgetown.edu/projects/pro/pro_wv.obo
-  
-
-# ISSUES
-# http://purl.obolibrary.org/obo/pr-asserted.obo
-#  resolves to
-# ftp://ftp.proconsortium.org/databases/ontology/pro_obo/pro.obo
-#  which is invalid.
-# http://purl.obolibrary.org/obo/pr/pr-asserted.obo  (the ID-policy-compliant format)
-#  also fails (attempts to go to purl.oclc.org)
-
 


### PR DESCRIPTION
Not all products currently produced were available in past releases. Therefore the versioned PURLs need to be customized to handle the differences. Prior to release 43.0 only non-reasoned OBO files were produced but after that there are both OBO and OWL reasoned and non-reasoned files. 

Also, there has been a large-scale move and rename of many PRO files so nearly all PURLs had to be revised.