### PR TITLE
Update pr.yml

### DIFF
--- a/config/pr.yml
+++ b/config/pr.yml
@@ -136,7 +136,7 @@ entries:
   replacement: http://sourceforge.net/tracker/?group_id=266825&atid=1135711
 
 - exact: /downloads
-  replacement: https://research.bioinformatics.udel.edu/PRO/data
+  replacement: https://research.bioinformatics.udel.edu/PRO/data/current
 
 - prefix: /wiki/
   replacement: https://pir17.georgetown.edu/confluence/display/PROWIKI/


### PR DESCRIPTION
Decided to make downloads PURL default to current release folder instead of all releases folder (to better mimic how it currently works)