### PR TITLE
Add PURL configuration for PHIPO

### DIFF
--- a/config/phipo.yml
+++ b/config/phipo.yml
@@ -1,0 +1,30 @@
+# PURL configuration for http://purl.obolibrary.org/obo/phipo
+
+idspace: PHIPO
+base_url: /obo/phipo
+
+products:
+- phipo.owl: https://raw.githubusercontent.com/PHI-base/phipo/master/phipo.owl
+- phipo.obo: https://raw.githubusercontent.com/PHI-base/phipo/master/phipo.obo
+
+term_browser: ontobee
+example_terms:
+- PHIPO_0000015
+
+entries:
+
+- prefix: /releases/
+  replacement: https://raw.githubusercontent.com/PHI-base/phipo/v
+
+- prefix: /tracker/
+  replacement: https://github.com/PHI-base/phipo/issues
+
+- prefix: /about/
+  replacement: http://www.ontobee.org/ontology/PHIPO?iri=http://purl.obolibrary.org/obo/
+
+- prefix: /imports/
+  replacement: https://github.com/PHI-base/phipo/tree/master/imports
+
+## generic fall-through, serve direct from github by default
+- prefix: /
+  replacement: https://raw.githubusercontent.com/PHI-base/phipo/master/


### PR DESCRIPTION
This is the configuration for the Pathogen-Host Interaction Phenotype Ontology.

The ontology source can be found at https://github.com/PHI-base/phipo

There are details of the ontology request here: https://github.com/OBOFoundry/OBOFoundry.github.io/issues/681