### PR TITLE
Fix malformed imports link in phipo.yml

### DIFF
--- a/config/phipo.yml
+++ b/config/phipo.yml
@@ -23,7 +23,7 @@ entries:
   replacement: http://www.ontobee.org/ontology/PHIPO?iri=http://purl.obolibrary.org/obo/
 
 - prefix: /imports/
-  replacement: https://github.com/PHI-base/phipo/tree/master/imports
+  replacement: https://github.com/PHI-base/phipo/tree/master/imports/
 
 ## generic fall-through, serve direct from github by default
 - prefix: /


### PR DESCRIPTION
The PURL configuration for PHIPO is missing a trailing space on its imports URL, meaning that when we try to process PHIPO with OWLAPI (or similar tools), we get malformed URLs like this:
```
https://github.com/PHI-base/phipo/tree/master/importsgo_import.owl
```
When the link should be like this:
https://github.com/PHI-base/phipo/tree/master/imports/go_import.owl

I've added a slash that should fix this.

**Note:** We generated this file with the [Ontology Development Kit](https://github.com/INCATools/ontology-development-kit), but I don't think the imports path is added automatically in the [template file](https://github.com/INCATools/ontology-development-kit/blob/master/template/.travis.yml), so this bug is probably an oversight on our part.