### PR TITLE
Direct PHIPO import links to raw content

### DIFF
--- a/config/phipo.yml
+++ b/config/phipo.yml
@@ -23,7 +23,7 @@ entries:
   replacement: http://www.ontobee.org/ontology/PHIPO?iri=http://purl.obolibrary.org/obo/
 
 - prefix: /imports/
-  replacement: https://github.com/PHI-base/phipo/tree/master/imports/
+  replacement: https://raw.githubusercontent.com/PHI-base/phipo/master/imports/
 
 ## generic fall-through, serve direct from github by default
 - prefix: /


### PR DESCRIPTION
(Follow-up from #460)

Sorry, but I've noticed another mistake in the PHIPO PURL configuration &ndash; the imports PURL was configured to redirect to the GitHub HTML page for the imports file (github.com), rather than the raw copy of the file (raw.githubusercontent.com), meaning the PURL couldn't be parsed by OWL or OBO parsers like Protege and OWLAPI. This pull request should fix that.