### PR TITLE
Update duo.yml

### DIFF
--- a/config/duo.yml
+++ b/config/duo.yml
@@ -17,13 +17,13 @@ entries:
   replacement: https://github.com/EBISPOT/DUO
   
 - prefix: /releases/
-  replacement: https://github.com/EBISPOT/DUO/releases/
+  replacement: https://raw.githubusercontent.com/EBISPOT/DUO/v
 
 - prefix: /tracker/
   replacement: https://github.com/EBISPOT/DUO/issues
 
 - prefix: /about/
-  replacement: https://www.ebi.ac.uk/ols/ontologies/duo
+  replacement: https://www.ebi.ac.uk/ols/ontologies/duo/
 
 ## generic fall-through, serve direct from github by default
 - prefix: /

--- a/config/duo.yml
+++ b/config/duo.yml
@@ -13,14 +13,17 @@ example_terms:
 
 entries:
 
+- prefix: /home/
+  replacement: https://github.com/EBISPOT/DUO
+  
 - prefix: /releases/
-  replacement: https://raw.githubusercontent.com/EBISPOT/DUO/v
+  replacement: https://github.com/EBISPOT/DUO/releases/
 
 - prefix: /tracker/
   replacement: https://github.com/EBISPOT/DUO/issues
 
 - prefix: /about/
-  replacement: http://www.ontobee.org/ontology/DUO?iri=http://purl.obolibrary.org/obo/
+  replacement: https://www.ebi.ac.uk/ols/ontologies/duo
 
 ## generic fall-through, serve direct from github by default
 - prefix: /


### PR DESCRIPTION
Added home
Updated releases and about link to point to the releases page on GH and to the OLS

@jamesaoverton the fall through doesn't seem to work properly can you help? I didn't update this and was hoping that using http://purl.obolibrary.org/obo/duo/ would redirect to the GH repo by default but it instead points to berkeley