### PR TITLE
temporary reversion to ftp for pr.owl only

### DIFF
--- a/config/pr.yml
+++ b/config/pr.yml
@@ -7,13 +7,17 @@ base_url: /obo/pr
 base_redirect: http://proconsortium.org
 
 products:
-- pr.owl: https://research.bioinformatics.udel.edu/PRO/data/current/pro_reasoned.owl
+- pr.owl: ftp://ftp.proconsortium.org/databases/ontology/pro_obo/pro_reasoned.owl
+# - pr.owl: https://research.bioinformatics.udel.edu/PRO/data/current/pro_reasoned.owl
 - pr.obo: https://research.bioinformatics.udel.edu/PRO/data/current/pro_reasoned.obo
 
 term_browser: custom
 
 entries:
 
+- exact: /pr.owl
+  replacement: ftp://ftp.proconsortium.org/databases/ontology/pro_obo/pro_reasoned.owl
+  
 ##### PURLs using major.minor style to indicate the release; this is the versioning format used by PRO #####
 # major releases prior to release 43.0; no reasoned version produced so default to non-reasoned; no OWL produced
 # The regex matches three sets of version numbers:


### PR DESCRIPTION
The need for --no-check-certificate seems to be foiling some users. Will temporarily use ftp for the main release file.