### PR TITLE
Add missing `exo.obo` product in `config/exo.yml`

### DIFF
--- a/config/exo.yml
+++ b/config/exo.yml
@@ -5,6 +5,7 @@ base_url: /obo/exo
 
 products:
 - exo.owl: http://ontologies.berkeleybop.org/exo.owl
+- exo.obo: https://github.com/CTDbase/exposure-ontology/raw/master/src/ontology/exo.obo
 
 term_browser: ontobee
 example_terms:

--- a/config/xlmod.yml
+++ b/config/xlmod.yml
@@ -1,0 +1,13 @@
+# PURL configuration for http://purl.obolibrary.org/obo/rnao
+
+idspace: XLMOD
+base_url: /obo/xlmod
+
+products:
+- xlmod.obo: https://raw.githubusercontent.com/HUPO-PSI/mzIdentML/master/cv/XLMOD.obo
+
+term_browser: ontobee
+
+entries:
+- exact: /tracker
+  replacement: https://github.com/HUPO-PSI/mzIdentML/issues


### PR DESCRIPTION
A couple of missing redirections that are affecting the OBO Foundry.