### PR TITLE
Use release versions of OMP ontology instead of BBOP backup

### DIFF
--- a/config/omp.yml
+++ b/config/omp.yml
@@ -4,8 +4,8 @@ idspace: OMP
 base_url: /obo/omp
 
 products:
-- omp.owl: http://ontologies.berkeleybop.org/omp.owl
-- omp.obo: http://ontologies.berkeleybop.org/omp.obo
+- omp.owl: https://raw.githubusercontent.com/microbialphenotypes/OMP-ontology/master/omp.owl
+- omp.obo: https://raw.githubusercontent.com/microbialphenotypes/OMP-ontology/master/omp.obo
 
 term_browser: ontobee
 example_terms:


### PR DESCRIPTION
Hi!

The current version of `omp.yaml` points to the BBOP version, which is outdated. Since OMP is released publicly on GitHub the links should refer to the released files instead.