### PR TITLE
Add json-artefact

### DIFF
--- a/config/hp.yml
+++ b/config/hp.yml
@@ -8,6 +8,7 @@ base_redirect: https://github.com/obophenotype/human-phenotype-ontology
 products:
 - hp.owl: https://raw.githubusercontent.com/obophenotype/human-phenotype-ontology/master/hp.owl
 - hp.obo: https://raw.githubusercontent.com/obophenotype/human-phenotype-ontology/master/hp.obo
+- hp.json: https://raw.githubusercontent.com/obophenotype/human-phenotype-ontology/master/hp.json
 
 term_browser: ontobee
 example_terms:


### PR DESCRIPTION
HPO has added the JSON version of HP to the set of artefacts. It would be great to resolve this correctly via the purl "http://purl.obolibrary.org/obo/hp.json"