### PR TITLE
Rename PDRO lowercase

### DIFF
--- a/config/pdro.yml
+++ b/config/pdro.yml
@@ -4,7 +4,7 @@ idspace: PDRO
 base_url: /obo/pdro
 
 products:
-- pdro.owl: https://raw.githubusercontent.com/OpenLHS/PDRO/master/PDRO.owl
+- pdro.owl: https://raw.githubusercontent.com/OpenLHS/PDRO/master/pdro.owl
 
 term_browser: ontobee
 example_terms:


### PR DESCRIPTION
Looks like the PDRO OWL file was renamed. This fixes the main PURL.