### PR TITLE
Update eupath.yml

### DIFF
--- a/config/eupath.yml
+++ b/config/eupath.yml
@@ -4,11 +4,22 @@ idspace: EUPATH
 base_url: /obo/eupath
 
 products:
-- eupath.owl: https://raw.githubusercontent.com/EuPath-ontology/EuPath-ontology/2019-09-04/eupath.owl
+- eupath.owl: https://raw.githubusercontent.com/VEuPathDB-ontology/VEuPathDB-ontology/2019-09-04/eupath.owl
 term_browser: ontobee
 example_terms:
 - EUPATH_0000001
 
 entries:
 - exact: /2019-09-04/eupath.owl
-  replacement: https://raw.githubusercontent.com/EuPath-ontology/EuPath-ontology/2019-09-04/eupath.owl
+  replacement: https://raw.githubusercontent.com/VEuPathDB-ontology/VEuPathDB-ontology/2019-09-04/eupath.owl
+
+- exact: /2019-04-02/eupath.owl
+  replacement: https://raw.githubusercontent.com/VEuPathDB-ontology/VEuPathDB-ontology/2019-04-02/eupath.owl
+  
+- exact: /2019-01-08/eupath.owl
+  replacement: https://raw.githubusercontent.com/VEuPathDB-ontology/VEuPathDB-ontology/2019-01-09/eupath.owl
+  
+- exact: /2018-05-09/eupath.owl
+  replacement: https://raw.githubusercontent.com/VEuPathDB-ontology/VEuPathDB-ontology/2018-05-09/ontology/src/eupath.owl
+
+  


### PR DESCRIPTION
The organization and repository of EuPathDB ontology were changed. So, update the links of files in github. Besides, add the missing version IRIs for previous EuPathDB ontology releases