### PR TITLE
Update gno.yml

### DIFF
--- a/config/gno.yml
+++ b/config/gno.yml
@@ -4,9 +4,9 @@ idspace: GNO
 base_url: /obo/gno
 
 products:
-- gno.owl: https://raw.githubusercontent.com/glygen-glycan-data/GNOme/master/GNOme.owl
-- gno.obo: https://raw.githubusercontent.com/glygen-glycan-data/GNOme/master/GNOme.obo
-- gno.json: https://raw.githubusercontent.com/glygen-glycan-data/GNOme/master/GNOme.json
+- gno.owl: https://github.com/glygen-glycan-data/GNOme/releases/latest/download/GNOme.owl
+- gno.obo: https://github.com/glygen-glycan-data/GNOme/releases/latest/download/GNOme.obo
+- gno.json: https://github.com/glygen-glycan-data/GNOme/releases/latest/download/GNOme.json
 
 term_browser: ontobee
 example_terms:


### PR DESCRIPTION
Update PURL URL to point to latest github (tagged) release rather than HEAD of github master branch. This solves two problems - a) intermediate checkins to the master branch between releases should not (necessarily) be the published version of the ontology, and b) github's 100MB limit means we cannot host the .owl (and other) products as repository files. 