### PR TITLE
Pin jsonschema to 3.0.2

### DIFF
--- a/tools/site.yml
+++ b/tools/site.yml
@@ -45,7 +45,7 @@
       pip: name=pathlib2 executable=pip3
 
     - name: Install jsonschema
-      pip: name=jsonschema executable=pip3
+      pip: name=jsonschema==3.0.2 executable=pip3
 
     - name: Clone the Git repo
       when: mode == "production"


### PR DESCRIPTION
`jsonschema` switched to a Python 3.8 feature that's not properly backwards compatible, and is breaking Travis. The most relevant issue is here:

https://github.com/Julian/jsonschema/issues/584

This blog post helped me isolate the fix the problem:

https://gaborschulz.com/blog/my-jupyter-notebook-stopped-working-after-recent-package-upgrade/

For now let's stick with an older version of `jsonschema`.

@cmungall @beckyjackson I expect this bug to hit the OBO registry eventually. When that happens just updating the requirements should work: 

https://github.com/OBOFoundry/OBOFoundry.github.io/blob/master/requirements.txt