### PR TITLE
Update bco.yml

### DIFF
--- a/config/bco.yml
+++ b/config/bco.yml
@@ -4,7 +4,7 @@ idspace: BCO
 base_url: /obo/bco
 
 products:
-- bco.owl: https://raw.githubusercontent.com/BiodiversityOntologies/bco/2016-12-14/bco.owl
+- bco.owl: https://raw.githubusercontent.com/BiodiversityOntologies/bco/master/bco.owl
 
 term_browser: ontobee
 
@@ -14,6 +14,10 @@ example_terms:
 entries:
 - exact: /bco-non-classified.owl
   replacement: https://raw.githubusercontent.com/BiodiversityOntologies/bco/2016-12-14/bco-non-classified.owl
+#bco-non-classified is no longer supported as of the release on 2020-03-27. Only the main product is now supported. Additional products (e.g. .obo files and base files) may be added with future releases. 
+
+- prefix: /releases/2020-03-27/
+  replacement: https://raw.githubusercontent.com/BiodiversityOntologies/bco/2020-03-27/
 
 - prefix: /releases/2016-12-14/
   replacement: https://raw.githubusercontent.com/BiodiversityOntologies/bco/2016-12-14/


### PR DESCRIPTION
Update file so that it now points to the bco.owl file in the repo root directory as the main release file, consistent with ODK repo structuring.

Add new prefix for this release.

No longer releasing a "non-classified" version with this release, but it may be added back in with the next release.