### PR TITLE
correcting github raw link format

### DIFF
--- a/config/so.yml
+++ b/config/so.yml
@@ -4,8 +4,8 @@ idspace: SO
 base_url: /obo/so
 
 products:
-- so.owl: https://github.com/The-Sequence-Ontology/SO-Ontologies/raw/master/Ontology_Files/so.owl
-- so.obo: https://github.com/The-Sequence-Ontology/SO-Ontologies/raw/master/Ontology_Files/so.obo
+- so.owl: https://raw.githubusercontent.com/The-Sequence-Ontology/SO-Ontologies/master/Ontology_Files/so.owl
+- so.obo: https://raw.githubusercontent.com/The-Sequence-Ontology/SO-Ontologies/master/Ontology_Files/so.obo
 
 term_browser: ontobee
 example_terms:
@@ -13,9 +13,9 @@ example_terms:
 
 entries:
 - prefix: /so-simple.obo
-  replacement: https://github.com/The-Sequence-Ontology/SO-Ontologies/raw/master/Ontology_Files/so-simple.obo
+  replacement: https://raw.githubusercontent.com/The-Sequence-Ontology/SO-Ontologies/master/Ontology_Files/so-simple.obo
 - prefix: /subsets/
-  replacement: https://github.com/The-Sequence-Ontology/SO-Ontologies/raw/master/Ontology_Files/subsets/
+  replacement: https://raw.githubusercontent.com/The-Sequence-Ontology/SO-Ontologies/master/Ontology_Files/subsets/
 - prefix: /about/
   replacement: http://www.ontobee.org/browser/rdf.php?o=SO&iri=http://purl.obolibrary.org/obo/
   tests:

--- a/config/so.yml
+++ b/config/so.yml
@@ -4,8 +4,8 @@ idspace: SO
 base_url: /obo/so
 
 products:
-- so.owl: https://raw.githubusercontent.com/The-Sequence-Ontology/SO-Ontologies/master/so.owl
-- so.obo: https://raw.githubusercontent.com/The-Sequence-Ontology/SO-Ontologies/master/so.obo
+- so.owl: https://github.com/The-Sequence-Ontology/SO-Ontologies/raw/master/Ontology_Files/so.owl
+- so.obo: https://github.com/The-Sequence-Ontology/SO-Ontologies/raw/master/Ontology_Files/so.obo
 
 term_browser: ontobee
 example_terms:
@@ -13,9 +13,9 @@ example_terms:
 
 entries:
 - prefix: /so-simple.obo
-  replacement: https://raw.githubusercontent.com/The-Sequence-Ontology/SO-Ontologies/master/so-simple.obo
+  replacement: https://github.com/The-Sequence-Ontology/SO-Ontologies/raw/master/Ontology_Files/so-simple.obo
 - prefix: /subsets/
-  replacement: https://raw.githubusercontent.com/The-Sequence-Ontology/SO-Ontologies/master/subsets/
+  replacement: https://github.com/The-Sequence-Ontology/SO-Ontologies/raw/master/Ontology_Files/subsets/
 - prefix: /about/
   replacement: http://www.ontobee.org/browser/rdf.php?o=SO&iri=http://purl.obolibrary.org/obo/
   tests:


### PR DESCRIPTION
http://purl.obolibrary.org/obo/so.owl is currently returning 404 as old raw URL is used.