### PR TITLE
Add PURL config for GECKO

### DIFF
--- a/config/gecko.yml
+++ b/config/gecko.yml
@@ -1,0 +1,15 @@
+# PURL configuration for http://purl.obolibrary.org/obo/gecko
+
+idspace: GECKO
+base_url: /obo/gecko
+
+products:
+- gecko.owl: https://raw.githubusercontent.com/IHCC-cohorts/GECKO/master/gecko.owl
+
+term_browser: ontobee
+example_terms:
+- GECKO_0000001
+
+entries:
+- prefix: /views/
+  replacement: https://raw.githubusercontent.com/IHCC-cohorts/GECKO/master/views/


### PR DESCRIPTION
GECKO has been approved - see OBOFoundry/OBOFoundry.github.io#1253
Corresponding metadata PR: https://github.com/OBOFoundry/OBOFoundry.github.io/pull/1257