### PR TITLE
Add IHCC view to GECKO products

### DIFF
--- a/config/gecko.yml
+++ b/config/gecko.yml
@@ -5,6 +5,7 @@ base_url: /obo/gecko
 
 products:
 - gecko.owl: https://raw.githubusercontent.com/IHCC-cohorts/GECKO/master/gecko.owl
+- ihcc-gecko.owl: https://raw.githubusercontent.com/IHCC-cohorts/GECKO/master/views/ihcc-gecko.owl
 
 term_browser: ontobee
 example_terms:

--- a/config/gecko.yml
+++ b/config/gecko.yml
@@ -5,13 +5,15 @@ base_url: /obo/gecko
 
 products:
 - gecko.owl: https://raw.githubusercontent.com/IHCC-cohorts/GECKO/master/gecko.owl
-- ihcc-gecko.owl: https://raw.githubusercontent.com/IHCC-cohorts/GECKO/master/views/ihcc-gecko.owl
 
 term_browser: ontobee
 example_terms:
 - GECKO_0000001
 
 entries:
+- exact: /ihcc-gecko.owl
+  replacement: https://raw.githubusercontent.com/IHCC-cohorts/GECKO/master/views/ihcc-gecko.owl
+
 - prefix: /views/
   replacement: https://raw.githubusercontent.com/IHCC-cohorts/GECKO/master/views/
 

--- a/config/gecko.yml
+++ b/config/gecko.yml
@@ -14,3 +14,6 @@ example_terms:
 entries:
 - prefix: /views/
   replacement: https://raw.githubusercontent.com/IHCC-cohorts/GECKO/master/views/
+
+- prefix: /releases/
+  replacement: https://raw.githubusercontent.com/IHCC-cohorts/GECKO/v


### PR DESCRIPTION
Adds `ihcc-gecko.owl` to products. Fixing the IRI for https://github.com/IHCC-cohorts/GECKO/issues/2

Also adds a `/releases/` path.