### PR TITLE
Update MRO config

### DIFF
--- a/config/mro.yml
+++ b/config/mro.yml
@@ -6,13 +6,21 @@ base_url: /obo/mro
 base_redirect: https://github.com/IEDB/MRO
 
 products:
-- mro.owl: https://raw.githubusercontent.com/IEDB/MRO/master/mro.owl
+- mro.owl: https://github.com/IEDB/MRO/releases/latest/download/mro.owl
 
 term_browser: ontobee
 example_terms:
 - MRO_0000012
 
 entries:
+
+### Dated Releases after 2020-10-07
+
+- exact: /2020-10-07/mro.owl
+  replacement: https://github.com/IEDB/MRO/releases/download/v2020-10-07/mro.owl
+
+### Dated Releases before 2020-10-07
+
 - prefix: /20
   replacement: https://raw.githubusercontent.com/IEDB/MRO/v20
   tests:


### PR DESCRIPTION
Due to an increase in size above 50GB, we have moved `mro.owl` out of the repository and now include it as a release binary. This PR updates the redirects for the location.

For dated releases:
We could update the `/20` prefix to point to the releases, but then we would lose everything before 2020-10-07. Perhaps we do that and then add those in as exact entries? Or we could add those products to the past releases. @jamesaoverton 