### PR TITLE
Update duo.yml

### DIFF
--- a/config/duo.yml
+++ b/config/duo.yml
@@ -3,6 +3,8 @@
 idspace: DUO
 base_url: /obo/duo
 
+base_redirect: https://github.com/EBISPOT/DUO
+
 products:
 - duo.owl: https://raw.githubusercontent.com/EBISPOT/DUO/master/duo.owl
 - duo.obo: https://raw.githubusercontent.com/EBISPOT/DUO/master/duo.obo


### PR DESCRIPTION
added base redirect so that http://purl.obolibrary.org/obo/duo points to https://github.com/EBISPOT/DUO