### PR TITLE
Update amphx.yml

### DIFF
--- a/config/amphx.yml
+++ b/config/amphx.yml
@@ -14,7 +14,7 @@ example_terms:
 entries:
 
 - prefix: /releases/
-  replacement: https://github.com/EBISPOT/amphx_ontology/releases/download/v
+  replacement: https://raw.githubusercontent.com/EBISPOT/amphx_ontology/v
 
 - prefix: /tracker/
   replacement: https://github.com/EBISPOT/amphx_ontology/issues
@@ -23,4 +23,4 @@ entries:
   replacement: http://www.ontobee.org/ontology/AMPHX?iri=http://purl.obolibrary.org/obo/
 
 - prefix: /
-  replacement: https://github.com/EBISPOT/amphx_ontology/releases/download/current/
+  replacement: https://github.com/EBISPOT/amphx_ontology/releases/latest

--- a/config/amphx.yml
+++ b/config/amphx.yml
@@ -23,4 +23,4 @@ entries:
   replacement: http://www.ontobee.org/ontology/AMPHX?iri=http://purl.obolibrary.org/obo/
 
 - prefix: /
-  replacement: https://github.com/EBISPOT/amphx_ontology/releases/latest
+  replacement: https://raw.githubusercontent.com/EBISPOT/amphx_ontology/master/


### PR DESCRIPTION
modified replacements for "/releases/" and "/" prefixes.

Previous ones were redirecting to GitHub 404

@matentzn  can you please review.

Thanks a lot !