### PR TITLE
Get rid of the whole "current" tag logic in Mondo

### DIFF
--- a/config/mondo.yml
+++ b/config/mondo.yml
@@ -4,9 +4,9 @@ idspace: MONDO
 base_url: /obo/mondo
 
 products:
-- mondo.owl: https://github.com/monarch-initiative/mondo/releases/download/current/mondo.owl
-- mondo.obo: https://github.com/monarch-initiative/mondo/releases/download/current/mondo.obo
-- mondo.json: https://github.com/monarch-initiative/mondo/releases/download/current/mondo.json
+- mondo.owl: https://github.com/monarch-initiative/mondo/releases/latest/download/mondo.owl
+- mondo.obo: https://github.com/monarch-initiative/mondo/releases/latest/download/mondo.obo
+- mondo.json: https://github.com/monarch-initiative/mondo/releases/latest/download/mondo.json
 
 term_browser: ontobee
 


### PR DESCRIPTION
Thanks to @jamesaoverton I now learned that you can actually reference the latest release without a current tag. This simplifies our release pipelines a lot!

@cmungall