### PR TITLE
Use owl version from VariO homepage

### DIFF
--- a/config/vario.yml
+++ b/config/vario.yml
@@ -4,7 +4,7 @@ idspace: VariO
 base_url: /obo/vario
 
 products:
-- vario.owl: http://ontologies.berkeleybop.org/vario.owl
+- vario.owl: http://www.variationontology.org/vario_download/vario.owl
 - vario.obo: http://www.variationontology.org/vario_download/vario.obo
 
 term_browser: ontobee


### PR DESCRIPTION
The OWL version of VariO on [bioportal](https://bioportal.bioontology.org/ontologies/VARIO) and their [homepage](http://variationontology.org/download.shtml) is newer with additional content compared to the one at http://ontologies.berkeleybop.org/vario.owl

This PR sets the config to use the ontology distributed from the homepage.

Note that it looks like the ontology was updated, but the timestamp and version was not ([diff](https://data.bioontology.org/ontologies/VARIO/submissions/16/download_diff?apikey=8b5b7825-538d-40e0-9e9e-5ab9274a9aeb). It also appears that the Version IRI (http://purl.obolibrary.org/obo/vario/2018-11-09/vario.owl) is missing from the homepage distribution but present in the berkeleybop distribution.

cc @MattBrauer