### PR TITLE
Brain Data Standards Ontology url redirection

### DIFF
--- a/config/cl.yml
+++ b/config/cl.yml
@@ -65,11 +65,11 @@ entries:
   - from: /about/CL_0000000
     to: http://www.ontobee.org/browser/rdf.php?o=CL&iri=http://purl.obolibrary.org/obo/CL_0000000
     
-- prefix: /bds
-  replacement: https://github.com/obophenotype/brain_data_standards_ontologies/tree/workshop_dosdp_improvement
+- prefix: /bds/
+  replacement: https://github.com/obophenotype/brain_data_standards_ontologies/tree/workshop_dosdp_improvement/
   
-- prefix: /bds/browser
-  replacement: http://ec2-3-143-113-50.us-east-2.compute.amazonaws.com:8080/ontologies/bds2
+- prefix: /bds/browser/
+  replacement: http://ec2-3-143-113-50.us-east-2.compute.amazonaws.com:8080/ontologies/bds2/
 
 ## generic fall-through, serve direct from github by default
 - prefix: /

--- a/config/cl.yml
+++ b/config/cl.yml
@@ -65,10 +65,10 @@ entries:
   - from: /about/CL_0000000
     to: http://www.ontobee.org/browser/rdf.php?o=CL&iri=http://purl.obolibrary.org/obo/CL_0000000
     
-- prefix: /bds/
+- prefix: /bds
   replacement: https://github.com/obophenotype/brain_data_standards_ontologies/tree/workshop_dosdp_improvement
   
-- prefix: /bds/browser/
+- prefix: /bds/browser
   replacement: http://ec2-3-143-113-50.us-east-2.compute.amazonaws.com:8080/ontologies/bds2
 
 ## generic fall-through, serve direct from github by default

--- a/config/cl.yml
+++ b/config/cl.yml
@@ -64,6 +64,12 @@ entries:
   tests:
   - from: /about/CL_0000000
     to: http://www.ontobee.org/browser/rdf.php?o=CL&iri=http://purl.obolibrary.org/obo/CL_0000000
+    
+- prefix: /bds/
+  replacement: https://github.com/obophenotype/brain_data_standards_ontologies/tree/workshop_dosdp_improvement
+  
+- prefix: /bds/browser/
+  replacement: http://ec2-3-143-113-50.us-east-2.compute.amazonaws.com:8080/ontologies/bds2
 
 ## generic fall-through, serve direct from github by default
 - prefix: /


### PR DESCRIPTION
Configuration update request to support Brain Data Standards Ontology as part of the Cell Ontology. 

Two new PURLs added for BDS ontology home page (`/bds/`) and custom OLS (`/bds/browser/`) instance redirections.