### PR TITLE
Switch order of bds prefix entries

### DIFF
--- a/config/cl.yml
+++ b/config/cl.yml
@@ -64,12 +64,12 @@ entries:
   tests:
   - from: /about/CL_0000000
     to: http://www.ontobee.org/browser/rdf.php?o=CL&iri=http://purl.obolibrary.org/obo/CL_0000000
-    
-- prefix: /bds/
-  replacement: https://github.com/obophenotype/brain_data_standards_ontologies/tree/workshop_dosdp_improvement/
-  
+
 - prefix: /bds/browser/
   replacement: http://ec2-3-143-113-50.us-east-2.compute.amazonaws.com:8080/ontologies/bds2/
+
+- prefix: /bds/
+  replacement: https://github.com/obophenotype/brain_data_standards_ontologies/tree/workshop_dosdp_improvement/
 
 ## generic fall-through, serve direct from github by default
 - prefix: /


### PR DESCRIPTION
FYI @hkir-dev: PURL entries match in order, so the `/bds/` entry was matching before `/bds/browser/` entry, and `/bds/browser/` could never be reached. I swapped the order of the two entries to fix this.

I missed this when I reviewed the PR, and the automated tests didn't catch it either, which is not how it's supposed to work.