### PR TITLE
Adding PURL to a release  4.1.1 of Apollo-SV

### DIFF
--- a/config/apollo_sv.yml
+++ b/config/apollo_sv.yml
@@ -23,6 +23,9 @@ entries:
 
 - exact: /3.0.1/apollo_sv.owl 
   replacement: https://raw.githubusercontent.com/ApolloDev/apollo-sv/v3.0.1/src/ontology/apollo-sv.owl
+  
+- exact: /v4.1.1/apollo_sv.owl
+  replacement: https://raw.githubusercontent.com/ApolloDev/apollo-sv/v4.1.1/src/ontology/apollo-sv.owl
 
 # Misc
 


### PR DESCRIPTION
The PURL to version 4.1.1 seems to have disappeared.