### PR TITLE
Update MS to current information

### DIFF
--- a/config/ms.yml
+++ b/config/ms.yml
@@ -14,7 +14,7 @@ example_terms:
 
 entries:
 - prefix: /releases/
-  replacement: https://github.com/HUPO-PSI/psi-ms-CV/tags
+  replacement: https://raw.githubusercontent.com/HUPO-PSI/psi-ms-CV/v
 
 - exact: /tracker
   replacement: https://github.com/HUPO-PSI/psi-ms-CV/issues
@@ -23,5 +23,5 @@ entries:
   replacement: https://psidev.info/groups/controlled-vocabularies
 
 - prefix: /
-  replacement: https://github.com/HUPO-PSI/psi-ms-CV
+  replacement: https://raw.githubusercontent.com/HUPO-PSI/psi-ms-CV/master/
 


### PR DESCRIPTION
PSI-MS is now managed in GitHub. Point directly there.