### PR TITLE
Add /2020/bfo.owl as alternative for ISO version due to error in copy on ISO portal

### DIFF
--- a/config/bfo.yml
+++ b/config/bfo.yml
@@ -153,6 +153,9 @@ entries:
 - exact: /iso/2020/bfo.owl
   replacement: https://raw.githubusercontent.com/BFO-ontology/BFO-2020/master/21838-2/owl/bfo-2020.owl
   
+- exact: /2020/bfo.owl
+  replacement: https://raw.githubusercontent.com/BFO-ontology/BFO-2020/master/21838-2/owl/bfo-2020.owl
+  
 - prefix: /2010-05-25/
   replacement: https://raw.githubusercontent.com/BFO-ontology/BFO/releases/owl-ruttenberg-2010-05-25/  
 


### PR DESCRIPTION
… 