### PR TITLE
Change DOID term browser to disease-ontology.org

### DIFF
--- a/config/doid.yml
+++ b/config/doid.yml
@@ -10,7 +10,7 @@ products:
 - doid.obo: https://raw.githubusercontent.com/DiseaseOntology/HumanDiseaseOntology/main/src/ontology/doid.obo
 - doid.json: https://raw.githubusercontent.com/DiseaseOntology/HumanDiseaseOntology/main/src/ontology/doid.json
 
-term_browser: ontobee
+term_browser: custom
 example_terms:
 - DOID_4
 

--- a/config/obo.yml
+++ b/config/obo.yml
@@ -152,6 +152,16 @@ entries:
   - from: /NCIT_C2916
     to: http://www.ontobee.org/ontology/NCIT?iri=http://purl.obolibrary.org/obo/NCIT_C2916
 
+# Term redirects for DOID
+- regex: ^/obo/DOID_(\d+)$
+  replacement: https://disease-ontology.org/?id=DOID:$1
+  status: see other
+  tests:
+  - from: /DOID_4
+    to: https://disease-ontology.org/?id=DOID:4
+  - from: /DOID_0014667
+    to: https://disease-ontology.org/?id=DOID:0014667
+
 ### OBO Format Specification
 - exact: /oboformat/
   replacement: http://owlcollab.github.io/oboformat/doc/obo-syntax.html


### PR DESCRIPTION
@lschriml asked that DOID term URLs be redirected to disease-ontology.org. _I believe_ this implements that change.

Is there a way to make OLS a backup, in case disease-ontology.org is down for some reason? Could this be implemented by setting DO's term_browser to 'ols' instead of 'custom'?

Thanks.