### PR TITLE
Adding purls for mondo source ingests

### DIFF
--- a/config/mondo.yml
+++ b/config/mondo.yml
@@ -21,6 +21,15 @@ entries:
   replacement: https://raw.githubusercontent.com/monarch-initiative/mondo/master/src/ontology/mappings/
 - prefix: /patterns/
   replacement: https://raw.githubusercontent.com/monarch-initiative/mondo/master/src/patterns/dosdp-patterns/
+- prefix: /sources/
+  replacement: https://github.com/monarch-initiative/mondo-ingest/releases/latest/download/
+- prefix: /sources/mappings/
+  replacement: https://github.com/monarch-initiative/mondo-ingest/releases/latest/download/
+- prefix: /sources/releases/
+  replacement: https://github.com/monarch-initiative/mondo-ingest/releases/download/v
+  tests:
+    - from: /sources/releases/2022-06-09/omim.owl
+      to: https://github.com/monarch-initiative/mondo-ingest/releases/download/v2022-06-09/omim.owl
 - prefix: /sparql/
   replacement: https://raw.githubusercontent.com/monarch-initiative/mondo/master/src/sparql/
 - prefix: /reports/


### PR DESCRIPTION
Note the @jamesaoverton 

/sources/mappings/ and /sources/ redirect to the same place.