### PR TITLE
Update rbo.yml

### DIFF
--- a/config/rbo.yml
+++ b/config/rbo.yml
@@ -5,6 +5,7 @@ base_url: /obo/rbo
 
 products:
 - rbo.owl: https://raw.githubusercontent.com/Radiobiology-Informatics-Consortium/RBO/master/rbo.owl
+- rbo.obo: https://raw.githubusercontent.com/DanBerrios/RBO/master/rbo.obo
 
 term_browser: ontobee
 example_terms:

--- a/config/rbo.yml
+++ b/config/rbo.yml
@@ -4,8 +4,7 @@ idspace: RBO
 base_url: /obo/rbo
 
 products:
-- rbo.owl: https://raw.githubusercontent.com/DanBerrios/RBO/master/rbo.owl
-- rbo.obo: https://raw.githubusercontent.com/DanBerrios/RBO/master/rbo.obo
+- rbo.owl: https://raw.githubusercontent.com/Radiobiology-Informatics-Consortium/RBO/master/rbo.owl
 
 term_browser: ontobee
 example_terms:
@@ -14,14 +13,14 @@ example_terms:
 entries:
 
 - prefix: /releases/
-  replacement: https://raw.githubusercontent.com/DanBerrios/RBO/v
+  replacement: https://raw.githubusercontent.com/Radiobiology-Informatics-Consortium/RBO/v
 
 - prefix: /tracker/
-  replacement: https://github.com/DanBerrios/RBO/issues
+  replacement: https://github.com/Radiobiology-Informatics-Consortium/RBO/issues
 
 - prefix: /about/
   replacement: http://www.ontobee.org/ontology/RBO?iri=http://purl.obolibrary.org/obo/
 
 ## generic fall-through, serve direct from github by default
 - prefix: /
-  replacement: https://raw.githubusercontent.com/DanBerrios/RBO/master/
+  replacement: https://raw.githubusercontent.com/Radiobiology-Informatics-Consortium/RBO/master/


### PR DESCRIPTION
See issue #855.  Removes OBO formatted RBO as product. Also updated the URLs for the repo to point to the GH org-hosted URLs instead of my personal GH space URLs (they are redirected already by GH but would rather they show the org).