### PR TITLE
Update dron.yml

### DIFF
--- a/config/dron.yml
+++ b/config/dron.yml
@@ -31,39 +31,6 @@ entries:
 - exact: /dev/dron-ingredient.owl
   replacement: https://s3.amazonaws.com/drugontology/dev/dron-ingredient.owl
 
-- exact: /dev/dron.owl
-  replacement: https://bitbucket.org/uamsdbmi/dron/raw/development/dron-full.owl
-
-- exact: /dev/dron-pro.owl
-  replacement: https://bitbucket.org/uamsdbmi/dron/raw/development/dron-pro.owl
-
-- exact: /dev/dron-upper.owl
-  replacement: https://bitbucket.org/uamsdbmi/dron/raw/development/dron-upper.owl
-
-- exact: /dev/dron-chebi.owl
-  replacement: https://bitbucket.org/uamsdbmi/dron/raw/development/dron-chebi.owl
-
-- exact: /dron-upper.owl
-  replacement: https://bitbucket.org/uamsdbmi/dron/raw/master/dron-upper.owl
-
-- exact: /dron-lite.owl
-  replacement: https://bitbucket.org/uamsdbmi/dron/raw/master/dron-lite.owl
-
-- exact: /dron-pro.owl
-  replacement: https://bitbucket.org/uamsdbmi/dron/raw/master/dron-pro.owl
-
-- exact: /dron-chebi.owl
-  replacement: https://bitbucket.org/uamsdbmi/dron/raw/master/dron-chebi.owl
-
-- exact: /dev/dron-lite.owl
-  replacement: https://bitbucket.org/uamsdbmi/dron/raw/development/dron-lite.owl
-
-- exact: /dev/dron-hand.owl
-  replacement: https://bitbucket.org/uamsdbmi/dron/raw/development/dron-hand.owl
-  
-- exact: /dron-hand.owl
-  replacement: https://bitbucket.org/uamsdbmi/dron/raw/master/dron-hand.owl
-
 - prefix: /releases/
   replacement: https://github.com/ufbmi/dron/releases/download/v
   tests:  


### PR DESCRIPTION
Deleting references to the old repository on bitbucket. Dron is now maintained and hosted on GitHub