### PR TITLE
Adding a product for gaz-countries

### DIFF
--- a/config/gaz.yml
+++ b/config/gaz.yml
@@ -7,6 +7,7 @@ products:
 - gaz.owl: http://ontologies.berkeleybop.org/gaz.owl
 - gaz.obo: http://ontologies.berkeleybop.org/gaz.obo
 
+entries:
 - exact: /gaz-countries.owl
   replacement: https://raw.githubusercontent.com/EnvironmentOntology/gaz/master/src/ontology/gaz_countries.owl
 

--- a/config/gaz.yml
+++ b/config/gaz.yml
@@ -6,6 +6,7 @@ base_url: /obo/gaz
 products:
 - gaz.owl: http://ontologies.berkeleybop.org/gaz.owl
 - gaz.obo: http://ontologies.berkeleybop.org/gaz.obo
+- gaz-countries.owl: https://raw.githubusercontent.com/EnvironmentOntology/gaz/master/src/ontology/gaz_countries.owl
 
 term_browser: ontobee
 example_terms:

--- a/config/gaz.yml
+++ b/config/gaz.yml
@@ -6,7 +6,9 @@ base_url: /obo/gaz
 products:
 - gaz.owl: http://ontologies.berkeleybop.org/gaz.owl
 - gaz.obo: http://ontologies.berkeleybop.org/gaz.obo
-- gaz-countries.owl: https://raw.githubusercontent.com/EnvironmentOntology/gaz/master/src/ontology/gaz_countries.owl
+
+- exact: /gaz-countries.owl
+  replacement: https://raw.githubusercontent.com/EnvironmentOntology/gaz/master/src/ontology/gaz_countries.owl
 
 term_browser: ontobee
 example_terms:


### PR DESCRIPTION
See: https://github.com/OBOFoundry/OBOFoundry.github.io/issues/2108

This PR makes the GAZ countries subset resolvable via its own URL, http://purl.obolibrary.org/obo/gaz/gaz-countries.owl