### PR TITLE
Make FlyBase URLs point to GitHub release assets.

### DIFF
--- a/config/dpo.yml
+++ b/config/dpo.yml
@@ -7,16 +7,16 @@ idspace: DPO
 base_url: /obo/dpo
 
 products:
-- dpo.owl: https://raw.githubusercontent.com/FlyBase/drosophila-phenotype-ontology/master/dpo.owl
-- dpo.obo: https://raw.githubusercontent.com/FlyBase/drosophila-phenotype-ontology/master/dpo.obo
-- dpo.json: https://raw.githubusercontent.com/FlyBase/drosophila-phenotype-ontology/master/dpo.json
+- dpo.owl: https://github.com/FlyBase/drosophila-phenotype-ontology/releases/latest/download/dpo.owl
+- dpo.obo: https://github.com/FlyBase/drosophila-phenotype-ontology/releases/latest/download/dpo.obo
+- dpo.json: https://github.com/FlyBase/drosophila-phenotype-ontology/releases/latest/download/dpo.json
 
 term_browser: ontobee
 
 entries:
 
 - prefix: /releases/
-  replacement: https://raw.githubusercontent.com/FlyBase/drosophila-phenotype-ontology/v
+  replacement: https://github.com/FlyBase/drosophila-phenotype-ontology/releases/download/v
 
 - prefix: /tracker/
   replacement: https://github.com/FlyBase/drosophila-phenotype-ontology/issues
@@ -26,4 +26,4 @@ entries:
 
 ## generic fall-through, serve direct from github by default
 - prefix: /
-  replacement: https://raw.githubusercontent.com/FlyBase/drosophila-phenotype-ontology/master/
+  replacement: https://github.com/FlyBase/drosophila-phenotype-ontology/releases/latest/download/

--- a/config/fbbt.yml
+++ b/config/fbbt.yml
@@ -6,10 +6,9 @@ base_url: /obo/fbbt
 base_redirect:  https://github.com/FlyBase/drosophila-anatomy-developmental-ontology/wiki
 
 products:
-- fbbt.owl: https://raw.githubusercontent.com/FlyBase/drosophila-anatomy-developmental-ontology/master/fbbt.owl
-- fbbt.obo: https://raw.githubusercontent.com/FlyBase/drosophila-anatomy-developmental-ontology/master/fbbt.obo
-- FBbt_RO.owl: http://purl.obolibrary.org/obo/fbbt/2011-09-06/FBbt_helper_relations.owl
-- fbbt.json: https://raw.githubusercontent.com/FlyBase/drosophila-anatomy-developmental-ontology/master/fbbt.json
+- fbbt.owl: https://github.com/FlyBase/drosophila-anatomy-developmental-ontology/releases/latest/download/fbbt.owl
+- fbbt.obo: https://github.com/FlyBase/drosophila-anatomy-developmental-ontology/releases/latest/download/fbbt.obo
+- fbbt.json: https://github.com/FlyBase/drosophila-anatomy-developmental-ontology/releases/latest/download/fbbt.json
 
 
 term_browser: ontobee
@@ -18,7 +17,7 @@ example_terms:
 
 entries:
 - prefix: /releases/
-  replacement: https://raw.githubusercontent.com/FlyBase/drosophila-anatomy-developmental-ontology/v
+  replacement: https://github.com/FlyBase/drosophila-anatomy-developmental-ontology/releases/download/v
 
 - exact: /vfb/demo/owled2014_demo.owl.
   replacement: https://raw.githubusercontent.com/VirtualFlyBrain/VFB_papers/master/owl/owled2014_demo.owl
@@ -174,5 +173,5 @@ entries:
   replacement: https://github.com/FlyBase/drosophila-anatomy-developmental-ontology/wiki
 
 - prefix: /
-  replacement: https://raw.githubusercontent.com/FlyBase/drosophila-anatomy-developmental-ontology/master/
+  replacement: https://github.com/FlyBase/drosophila-anatomy-developmental-ontology/releases/latest/download/
 

--- a/config/fbcv.yml
+++ b/config/fbcv.yml
@@ -6,9 +6,9 @@ base_url: /obo/fbcv
 base_redirect: https://github.com/FlyBase/flybase-controlled-vocabulary/wiki
 
 products:
-- fbcv.owl: https://raw.githubusercontent.com/FlyBase/flybase-controlled-vocabulary/master/fbcv.owl
-- fbcv.obo: https://raw.githubusercontent.com/FlyBase/flybase-controlled-vocabulary/master/fbcv.obo
-- fbcv.json: https://raw.githubusercontent.com/FlyBase/flybase-controlled-vocabulary/master/fbcv.json
+- fbcv.owl: https://github.com/FlyBase/flybase-controlled-vocabulary/releases/latest/download/fbcv.owl
+- fbcv.obo: https://github.com/FlyBase/flybase-controlled-vocabulary/releases/latest/download/fbcv.obo
+- fbcv.json: https://github.com/FlyBase/flybase-controlled-vocabulary/releases/latest/download/fbcv.json
 
 term_browser: ontobee
 example_terms:
@@ -22,7 +22,7 @@ entries:
   replacement: https://github.com/FlyBase/flybase-controlled-vocabulary/wiki
 
 - exact: /fbcv-flybase.obo
-  replacement: https://raw.githubusercontent.com/FlyBase/flybase-controlled-vocabulary/master/fbcv-flybase.obo
+  replacement: https://github.com/FlyBase/flybase-controlled-vocabulary/releases/latest/download/flybase_controlled_vocabulary.obo
 
 - prefix: /about/
   replacement: http://www.ontobee.org/browser/rdf.php?o=FBcv&iri=http://purl.obolibrary.org/obo/
@@ -70,7 +70,7 @@ entries:
   replacement: https://raw.githubusercontent.com/FlyBase/flybase-controlled-vocabulary/master/releases/2018-01-03/
  
 - prefix: /releases/
-  replacement: https://raw.githubusercontent.com/FlyBase/flybase-controlled-vocabulary/v
+  replacement: https://github.com/FlyBase/flybase-controlled-vocabulary/releases/download/v
 
 - prefix: /
-  replacement: https://raw.githubusercontent.com/FlyBase/flybase-controlled-vocabulary/master/
+  replacement: https://github.com/FlyBase/flybase-controlled-vocabulary/releases/latest/download/

--- a/config/fbdv.yml
+++ b/config/fbdv.yml
@@ -6,9 +6,9 @@ base_url: /obo/fbdv
 base_redirect: https://github.com/FlyBase/drosophila-anatomy-developmental-ontology/wiki
 
 products:
-- fbdv.owl: https://raw.githubusercontent.com/FlyBase/drosophila-developmental-ontology/master/fbdv.owl
-- fbdv.obo: https://raw.githubusercontent.com/FlyBase/drosophila-developmental-ontology/master/fbdv.obo
-- fbdv.json: https://raw.githubusercontent.com/FlyBase/drosophila-developmental-ontology/master/fbdv.json
+- fbdv.owl: https://github.com/FlyBase/drosophila-developmental-ontology/releases/latest/download/fbdv.owl
+- fbdv.obo: https://github.com/FlyBase/drosophila-developmental-ontology/releases/latest/download/fbdv.obo
+- fbdv.json: https://github.com/FlyBase/drosophila-developmental-ontology/releases/latest/download/fbdv.json
 
 term_browser: ontobee
 example_terms:
@@ -16,7 +16,7 @@ example_terms:
 
 entries:
 - prefix: /releases/
-  replacement: https://raw.githubusercontent.com/FlyBase/drosophila-developmental-ontology/v
+  replacement: https://github.com/FlyBase/drosophila-developmental-ontology/releases/download/v
 
 - exact: /tracker
   replacement: https://github.com/FlyBase/drosophila-developmental-ontology/issues
@@ -28,5 +28,5 @@ entries:
   replacement: http://www.ontobee.org/browser/rdf.php?o=FBdv&iri=http://purl.obolibrary.org/obo/
 
 - prefix: /
-  replacement: https://raw.githubusercontent.com/FlyBase/drosophila-developmental-ontology/master/
+  replacement: https://github.com/FlyBase/drosophila-developmental-ontology/releases/latest/download/
 


### PR DESCRIPTION
This PR updates the configuration for the main FlyBase ontologies (FBdv, FBbt, DPO, FBcv) so that the artefacts are downloaded from GitHub release assets rather than from repository files.