### PR TITLE
Make TRANS versionIRI resolvable

### DIFF
--- a/config/trans.yml
+++ b/config/trans.yml
@@ -12,3 +12,11 @@ products:
 term_browser: ontobee
 example_terms:
 - TRANS_0000000
+
+- regex: ^/obo/trans/releases/([^\s/]+)/(\S+)$
+  replacement: https://raw.githubusercontent.com/DiseaseOntology/PathogenTransmissionOntology/v$1/src/ontology/$2
+  tests:
+  - from: /releases/2022-10-10/trans.owl
+    to: https://raw.githubusercontent.com/DiseaseOntology/PathogenTransmissionOntology/v2022-10-10/src/ontology/trans.owl
+  - from: /releases/2022-10-10/trans.obo
+    to: https://raw.githubusercontent.com/DiseaseOntology/SymptomOntology/v2022-10-10/src/ontology/trans.obo

--- a/config/trans.yml
+++ b/config/trans.yml
@@ -13,10 +13,12 @@ term_browser: ontobee
 example_terms:
 - TRANS_0000000
 
+entries:
+
 - regex: ^/obo/trans/releases/([^\s/]+)/(\S+)$
   replacement: https://raw.githubusercontent.com/DiseaseOntology/PathogenTransmissionOntology/v$1/src/ontology/$2
   tests:
   - from: /releases/2022-10-10/trans.owl
     to: https://raw.githubusercontent.com/DiseaseOntology/PathogenTransmissionOntology/v2022-10-10/src/ontology/trans.owl
   - from: /releases/2022-10-10/trans.obo
-    to: https://raw.githubusercontent.com/DiseaseOntology/SymptomOntology/v2022-10-10/src/ontology/trans.obo
+    to: https://raw.githubusercontent.com/DiseaseOntology/PathogenTransmissionOntology/v2022-10-10/src/ontology/trans.obo


### PR DESCRIPTION
To fix the versionIRI resolvability error of the Pathogen Transmission Ontology on the OBO dashboard.