### PR TITLE
Add new major artefact for Uberon.

### DIFF
--- a/config/uberon.yml
+++ b/config/uberon.yml
@@ -33,6 +33,12 @@ entries:
 - exact: /composite-metazoan.obo
   replacement: https://github.com/obophenotype/uberon/releases/latest/download/composite-metazoan.obo
 
+- exact: /collected-metazoan.owl
+  replacement: https://github.com/obophenotype/uberon/releases/latest/download/collected-metazoan.owl
+
+- exact: /collected-metazoan.obo
+  replacement: https://github.com/obophenotype/uberon/releases/latest/download/collected-metazoan.obo
+
 - exact: /ext.owl
   replacement: https://github.com/obophenotype/uberon/releases/latest/download/uberon.owl
 


### PR DESCRIPTION
Starting from the December 2023 release, Uberon will have a new “major” release artefact, `collected-metazoan.owl`. This PR updates the configuration for Uberon make the IRI of that product resolvable.