### PR TITLE
Update DISDRIV purl redirects

### DIFF
--- a/config/disdriv.yml
+++ b/config/disdriv.yml
@@ -3,11 +3,24 @@
 idspace: DISDRIV
 base_url: /obo/disdriv
 
-
 products:
-- disdriv.owl: https://raw.githubusercontent.com/DiseaseOntology/DiseaseDriversOntology/main/src/ontology/releases/disdriv.owl
+- disdriv.owl: https://raw.githubusercontent.com/DiseaseOntology/DiseaseDriversOntology/main/src/ontology/disdriv.owl
 
 term_browser: ontobee
 example_terms:
 - DISDRIV_0000002
 
+entries:
+
+- regex: ^/obo/disdriv/releases/([^\s/]+)/(\S+)$
+  replacement: https://raw.githubusercontent.com/DiseaseOntology/DiseaseDriversOntology/v$1/src/ontology/$2
+  tests:
+  - from: /releases/2023-12-15/disdriv.owl
+    to: https://raw.githubusercontent.com/DiseaseOntology/DiseaseDriversOntology/v2023-12-15/src/ontology/disdriv.owl
+
+# generic fall-back (rules processed in order = keep at bottom)
+- prefix: /
+  replacement: https://raw.githubusercontent.com/DiseaseOntology/DiseaseDriversOntology/main/src/ontology/
+  tests:
+  - from: /disdriv.owl
+    to: https://raw.githubusercontent.com/DiseaseOntology/DiseaseDriversOntology/main/src/ontology/disdriv.owl


### PR DESCRIPTION
These are fixes to ensure DISDRIV passes the OBO dashboard.
- Updated the ontology IRI redirect: DISDRIV's products will live in the src/ontology directory, for the time-being.
- Added versionIRI redirect
- Added a geneic fallback

A new release dated today was created for DISDRIV with corresponding adjustments to files in the repository to appropriately support these redirects. 

Note: I tried to test this with a vagrant VM to ensure everything was working properly but was unable to get the `make all` or `make build` commands to work. It complained about jsonschema exceptions.