### PR TITLE
PCL ontologies as release assets

### DIFF
--- a/config/pcl.yml
+++ b/config/pcl.yml
@@ -4,8 +4,10 @@ idspace: PCL
 base_url: /obo/pcl
 
 products:
-- pcl.owl: https://raw.githubusercontent.com/obophenotype/provisional_cell_ontology/master/pcl-base.owl
-- pcl.obo: https://raw.githubusercontent.com/obophenotype/provisional_cell_ontology/master/pcl-base.obo
+- pcl.owl: https://github.com/obophenotype/provisional_cell_ontology/releases/latest/download/pcl.owl
+- pcl.obo: https://github.com/obophenotype/provisional_cell_ontology/releases/latest/download/pcl.obo
+- pcl-base.owl: https://github.com/obophenotype/provisional_cell_ontology/releases/latest/download/pcl-base.owl
+- pcl-base.obo: https://github.com/obophenotype/provisional_cell_ontology/releases/latest/download/pcl-base.obo
 
 term_browser: ols
 example_terms:
@@ -13,12 +15,30 @@ example_terms:
 
 entries:
 
-# purl.obolibrary.org/obo/pcl/releases/2024-01-05/pcl-base.obo
+- exact: /pcl-base.obo
+  replacement: https://github.com/obophenotype/provisional_cell_ontology/releases/latest/download/pcl-base.obo
+
+- exact: /pcl-base.owl
+  replacement: https://github.com/obophenotype/provisional_cell_ontology/releases/latest/download/pcl-base.owl
+
+- exact: /pcl-simple.owl
+  replacement: https://github.com/obophenotype/provisional_cell_ontology/releases/latest/download/pcl-simple.owl
+
+- exact: /pcl-simple.obo
+  replacement: https://github.com/obophenotype/provisional_cell_ontology/releases/latest/download/pcl-simple.obo
+
+- exact: /pcl-cl-full.owl
+  replacement: https://github.com/obophenotype/provisional_cell_ontology/releases/latest/download/pcl-cl-full.owl
+
+- exact: /pcl-cl-full.obo
+  replacement: https://github.com/obophenotype/provisional_cell_ontology/releases/latest/download/pcl-cl-full.obo
+
+# http://purl.obolibrary.org/obo/pcl/releases/2024-01-05/pcl-base.obo
 - prefix: /releases/
-  replacement: https://raw.githubusercontent.com/obophenotype/provisional_cell_ontology/v
+  replacement: https://github.com/obophenotype/provisional_cell_ontology/releases/download/v
   tests:
-    - from: /releases/2024-01-05/
-      to: https://raw.githubusercontent.com/obophenotype/provisional_cell_ontology/v2024-01-05/
+  - from: /releases/2024-01-05/pcl-base.obo
+    to: https://github.com/obophenotype/provisional_cell_ontology/releases/download/v2024-01-05/pcl-base.obo
 
 - prefix: /tracker/
   replacement: https://github.com/obophenotype/provisional_cell_ontology/issues
@@ -37,7 +57,7 @@ entries:
 
 - prefix: /bds/api/
   replacement: https://bkp-cts-prod.aibs-bmp-prod.net/bds/
-
-### generic fall-through, serve direct from github by default
+  
+## generic fall-through, serve direct from github by default
 - prefix: /
-  replacement: https://raw.githubusercontent.com/obophenotype/provisional_cell_ontology/master/
+  replacement: https://github.com/obophenotype/provisional_cell_ontology/releases/latest/download/

--- a/config/pcl.yml
+++ b/config/pcl.yml
@@ -6,8 +6,6 @@ base_url: /obo/pcl
 products:
 - pcl.owl: https://github.com/obophenotype/provisional_cell_ontology/releases/latest/download/pcl.owl
 - pcl.obo: https://github.com/obophenotype/provisional_cell_ontology/releases/latest/download/pcl.obo
-- pcl-base.owl: https://github.com/obophenotype/provisional_cell_ontology/releases/latest/download/pcl-base.owl
-- pcl-base.obo: https://github.com/obophenotype/provisional_cell_ontology/releases/latest/download/pcl-base.obo
 
 term_browser: ols
 example_terms:


### PR DESCRIPTION
PCL ontologies are provided as release assets now. PURLs updated accordingly