### PR TITLE
Add redirection for deprecated Uberon-to-NIFSTD bridge.

### DIFF
--- a/config/uberon.yml
+++ b/config/uberon.yml
@@ -48,6 +48,14 @@ entries:
 - exact: /experimental/ceph.owl
   replacement: http://purl.obolibrary.org/obo/ceph.owl
 
+# The Uberon bridge to the "NIF Gross Anatomy" is deprecated but is still
+# imported by some old ontologies.
+- exact: /bridge/uberon-bridge-to-nifstd.obo
+  replacement: https://raw.githubusercontent.com/obophenotype/uberon/v2023-10-27/src/ontology/bridge/uberon-bridge-to-nifstd.obo
+
+- exact: /bridge/uberon-bridge-to-nifstd.owl
+  replacement: https://raw.githubusercontent.com/obophenotype/uberon/v2023-10-27/src/ontology/bridge/uberon-bridge-to-nifstd.owl
+
 - prefix: /subsets/
   replacement: https://github.com/obophenotype/uberon/releases/latest/download/
 


### PR DESCRIPTION
The Uberon bridge to the "NIF Gross Anatomy" is deprecated and no longer maintained, but is apparently still imported by some old ontologies, so we redirect its PURL to the latest release of Uberon where that bridge was still present.

See https://github.com/obophenotype/uberon/pull/3195