### PR TITLE
Add purls for the NFDI4Plants ontology

### DIFF
--- a/config/dpbo.yml
+++ b/config/dpbo.yml
@@ -1,0 +1,17 @@
+# PURL configuration for http://purl.obolibrary.org/obo/dpbo
+
+idspace: DPBO
+base_url: /obo/dpbo
+
+products:
+- dpbo.owl: https://raw.githubusercontent.com/nfdi4plants/nfdi4plants_ontology/main/DPBO.owl
+- dpbo.obo: https://raw.githubusercontent.com/nfdi4plants/nfdi4plants_ontology/main/dpbo.obo
+
+term_browser: custom
+
+example_terms:
+- DPBO_1000110
+
+entries:
+- exact: /wiki
+  replacement: https://github.com/nfdi4plants/nfdi4plants_ontology/tree/main

--- a/config/obo.yml
+++ b/config/obo.yml
@@ -145,6 +145,14 @@ entries:
   - from: /DOID_0014667
     to: https://disease-ontology.org/?id=DOID:0014667
 
+# Term redirects for DPBO
+- regex: ^/obo/DPBO_(\d+)$
+  replacement: https://terminology.tib.eu/ts/ontologies/dpbo/terms?iri=http://purl.obolibrary.org/obo/DPBO_$1
+  status: see other
+  tests:
+  - from: /DPBO_1000110
+    to: https://terminology.tib.eu/ts/ontologies/dpbo/terms?iri=http://purl.obolibrary.org/obo/DPBO_1000110
+
 ### OBO Format Specification
 - exact: /oboformat/
   replacement: http://owlcollab.github.io/oboformat/doc/obo-syntax.html


### PR DESCRIPTION
In our project, NFDI4Plants, we created an ontology that we are using in our tools. We auto-create purls based on the obolibrary purl pattern and would like to make the links direct our users to a specific lookup service. I tried to add the correct configuration for the custom term browser in the obo.yml file already, but please have another look to make sure nothing is affecting other projects. This pull request is linked to the issue #986 