### PR TITLE
Add a stable URL for an old BFO mireot import to sepio.yml

### DIFF
--- a/config/sepio.yml
+++ b/config/sepio.yml
@@ -12,6 +12,9 @@ example_terms:
 
 entries:
 
+- exact: /bfo-mireot.owl
+  replacement: https://raw.githubusercontent.com/monarch-initiative/SEPIO-ontology/master/src/ontology/mireots/bfo-mireot.owl
+
 - prefix: /releases/
   replacement: https://raw.githubusercontent.com/monarch-initiative/SEPIO-ontology/v
 


### PR DESCRIPTION
A user notified us that old versions of the sepio ontology dont parse anymore because of an import that has since been discontinued. Here we are adding it back, so that older versions can load normally again. 

For context see https://github.com/monarch-initiative/SEPIO-ontology/issues/46