### PR TITLE
Update cl.yml - images base

### DIFF
--- a/config/cl.yml
+++ b/config/cl.yml
@@ -98,6 +98,9 @@ entries:
   - from: /releases/2023-01-09/cl.obo
     to: https://github.com/obophenotype/cell-ontology/releases/download/v2023-01-09/cl.obo
 
+- prefix: /images/
+  replacement: https://github.com/obophenotype/cell-ontology/tree/master/images/
+
 - prefix: /tracker/
   replacement: https://code.google.com/p/cell-ontology/issues/detail?id=
 

--- a/config/cl.yml
+++ b/config/cl.yml
@@ -99,7 +99,7 @@ entries:
     to: https://github.com/obophenotype/cell-ontology/releases/download/v2023-01-09/cl.obo
 
 - prefix: /images/
-  replacement: https://github.com/obophenotype/cell-ontology/tree/master/images/
+  replacement: https://raw.githubusercontent.com/obophenotype/cell-ontology/master/images/
 
 - prefix: /tracker/
   replacement: https://code.google.com/p/cell-ontology/issues/detail?id=


### PR DESCRIPTION
Adding images folder redirect.  This will be used for PURLs to images store on the CL repo for linking to CL terms.

Fixes #1008 