### PR TITLE
Update config for some taxon-specific life-stages ontologies.

### DIFF
--- a/config/hsapdv.yml
+++ b/config/hsapdv.yml
@@ -4,8 +4,9 @@ idspace: HsapDv
 base_url: /obo/hsapdv
 
 products:
-- hsapdv.owl: https://raw.githubusercontent.com/obophenotype/developmental-stage-ontologies/master/src/hsapdv/hsapdv.owl
-- hsapdv.obo: https://raw.githubusercontent.com/obophenotype/developmental-stage-ontologies/master/src/hsapdv/hsapdv.obo
+- hsapdv.owl: https://github.com/obophenotype/developmental-stage-ontologies/releases/latest/download/hsapdv.owl
+- hsapdv.obo: https://github.com/obophenotype/developmental-stage-ontologies/releases/latest/download/hsapdv.obo
+- hsapdv.json: https://github.com/obophenotype/developmental-stage-ontologies/releases/latest/download/hsapdv.json
 
 term_browser: ontobee
 example_terms:

--- a/config/mmusdv.yml
+++ b/config/mmusdv.yml
@@ -4,8 +4,9 @@ idspace: MmusDv
 base_url: /obo/mmusdv
 
 products:
-- mmusdv.owl: https://raw.githubusercontent.com/obophenotype/developmental-stage-ontologies/master/src/mmusdv/mmusdv.owl
-- mmusdv.obo: https://raw.githubusercontent.com/obophenotype/developmental-stage-ontologies/master/src/mmusdv/mmusdv.obo
+- mmusdv.owl: https://github.com/obophenotype/developmental-stage-ontologies/releases/latest/download/mmusdv.owl
+- mmusdv.obo: https://github.com/obophenotype/developmental-stage-ontologies/releases/latest/download/mmusdv.obo
+- mmusdv.json: https://github.com/obophenotype/developmental-stage-ontologies/releases/latest/download/mmusdv.json
 
 term_browser: ontobee
 example_terms:

--- a/config/olatdv.yml
+++ b/config/olatdv.yml
@@ -4,8 +4,8 @@ idspace: OlatDv
 base_url: /obo/olatdv
 
 products:
-- olatdv.owl: https://raw.githubusercontent.com/obophenotype/developmental-stage-ontologies/master/src/olatdv/olatdv.owl
-- olatdv.obo: https://raw.githubusercontent.com/obophenotype/developmental-stage-ontologies/master/src/olatdv/olatdv.obo
+- olatdv.owl: https://raw.githubusercontent.com/obophenotype/developmental-stage-ontologies/master/src/ontology/components/olatdv.owl
+- olatdv.obo: https://raw.githubusercontent.com/obophenotype/developmental-stage-ontologies/master/src/ontology/components/olatdv.obo
 
 term_browser: ontobee
 example_terms:

--- a/config/pdumdv.yml
+++ b/config/pdumdv.yml
@@ -4,8 +4,8 @@ idspace: PdumDv
 base_url: /obo/pdumdv
 
 products:
-- pdumdv.owl: https://raw.githubusercontent.com/obophenotype/developmental-stage-ontologies/master/src/pdumdv/pdumdv.owl
-- pdumdv.obo: https://raw.githubusercontent.com/obophenotype/developmental-stage-ontologies/master/src/pdumdv/pdumdv.obo
+- pdumdv.owl: https://raw.githubusercontent.com/obophenotype/developmental-stage-ontologies/master/src/ontology/components/pdumdv.owl
+- pdumdv.obo: https://raw.githubusercontent.com/obophenotype/developmental-stage-ontologies/master/src/ontology/components/pdumdv.obo
 
 term_browser: ontobee
 example_terms:


### PR DESCRIPTION
The repository where the HsapDv, MmusDv, OlatDv, and PdumDv ontologies (among others) are maintained is undergoing an overhaul that will break the existing PURLs for those ontologies. This commit updates the corresponding configuration files to make the PURLs point to the new location of the latest version of those ontologies.