### PR TITLE
Update ms.yml

### DIFF
--- a/config/ms.yml
+++ b/config/ms.yml
@@ -4,7 +4,8 @@ idspace: MS
 base_url: /obo/ms
 
 products:
-- ms.owl: https://github.com/HUPO-PSI/psi-ms-CV/releases/latest/download/psi-ms.owl
+- ms.owl: https://github.com/HUPO-PSI/psi-ms-CV/releases/latest/download/ms.owl
+- psi-ms.owl: https://github.com/HUPO-PSI/psi-ms-CV/releases/latest/download/psi-ms.owl
 - ms.obo: https://github.com/HUPO-PSI/psi-ms-CV/releases/latest/download/psi-ms.obo
 
 term_browser: ontobee
@@ -13,20 +14,33 @@ example_terms:
 - MS_0000000
 
 entries:
-- prefix: /releases/
-  replacement: https://github.com/HUPO-PSI/psi-ms-CV/releases/download/v
-  tests:  
-    - from: /releases/4.1.86/psi-ms.owl
-      to: https://github.com/HUPO-PSI/psi-ms-CV/releases/download/v4.1.86/psi-ms.owl
-    - from: /releases/4.1.86/psi-ms.obo
-      to: https://github.com/HUPO-PSI/psi-ms-CV/releases/download/v4.1.86/psi-ms.obo
-
 - exact: /tracker
   replacement: https://github.com/HUPO-PSI/psi-ms-CV/issues
 
 - prefix: /about/
   replacement: https://psidev.info/groups/controlled-vocabularies
 
+- prefix: /home
+  replacement: https://github.com/HUPO-PSI/psi-ms-CV
+
+# intercept exact matches before version prefix blindly grabs everything
+- exact: /ms.owl
+  replacement: https://github.com/HUPO-PSI/psi-ms-CV/releases/latest/download/ms.owl
+- exact: /psi-ms.owl
+  replacement: https://github.com/HUPO-PSI/psi-ms-CV/releases/latest/download/psi-ms.owl
+- exact: /ms.obo
+  replacement: https://github.com/HUPO-PSI/psi-ms-CV/releases/latest/download/psi-ms.obo
+- exact: /psi-ms.obo
+  replacement: https://github.com/HUPO-PSI/psi-ms-CV/releases/latest/download/psi-ms.obo
+
+  
+# support directly resolving versioned IRIs
 - prefix: /
-  replacement: https://raw.githubusercontent.com/HUPO-PSI/psi-ms-CV/master/
+  replacement: https://github.com/HUPO-PSI/psi-ms-CV/releases/download/v
+  tests:  
+    - from: /4.1.186/ms.owl
+      to: https://github.com/HUPO-PSI/psi-ms-CV/releases/download/v4.1.86/ms.owl
+    - from: /4.1.86/psi-ms.obo
+      to: https://github.com/HUPO-PSI/psi-ms-CV/releases/download/v4.1.86/psi-ms.obo
+
 


### PR DESCRIPTION
This is an attempt to solve https://github.com/HUPO-PSI/psi-ms-CV/issues/259 without rewriting how our OWL files are generated.

It keeps the names the same, but should now resolve versioned pURLs.

I am unable to setup a test VM at the moment, so I couldn't test how the blind `prefix: /` rule would interact with `products`. From running the `translate_yaml.py` script, it didn't seem like `products` produced a rule in the generated `.htaccess` file. If this would introduce a conflict, they can be removed?