### PR TITLE
Update cob.yml

### DIFF
--- a/config/cob.yml
+++ b/config/cob.yml
@@ -12,7 +12,7 @@ example_terms:
 
 entries:
 - exact: /cob-to-external.owl
-  replacement: https://raw.githubusercontent.com/OBOFoundry/COB/master/src/ontology/components/cob-to-external.owl
+  replacement: https://raw.githubusercontent.com/OBOFoundry/COB/master/cob.owl
 - prefix: /branch/
   replacement: https://raw.githubusercontent.com/OBOFoundry/COB/
 - prefix: /releases/


### PR DESCRIPTION
I think that `cob-to-external.owl` no longer makes sense, and everyone should use the primary `cob.owl`.