### PR TITLE
Make sure CL's IRIs for imported files are resolvable.

### DIFF
--- a/config/cl.yml
+++ b/config/cl.yml
@@ -136,6 +136,20 @@ entries:
 - prefix: /bds/
   replacement: https://github.com/obophenotype/brain_data_standards_ontologies/
 
+# For files that are imported from the -edit file (imports, components,
+# pattern-derived definitions), we cannot point to the latest release
+# download folder as we do below in the "generic" fall-through, because
+# those files are _not_ release artefacts and are therefore absent from
+# that folder. Instead, we point to the current master branch.
+- prefix: /imports/
+  replacement: https://github.com/obophenotype/cell-ontology/raw/refs/heads/master/src/ontology/imports/
+
+- prefix: /components/
+  replacement: https://github.com/obophenotype/cell-ontology/raw/refs/heads/master/src/ontology/components/
+
+- prefix: /patterns/
+  replacement: https://github.com/obophenotype/cell-ontology/raw/refs/heads/master/src/patterns/
+
 ## generic fall-through, serve direct from github by default
 - prefix: /
   replacement: https://github.com/obophenotype/cell-ontology/releases/latest/download/


### PR DESCRIPTION
This PR adds special rules in the CL configuration for the three types of IRIs that are used in OWL import declarations within the ontology's edit file (imports, components, and pattern-derived definitions). The corresponding files are not release artefacts, so if we redirect those IRIs using the default generic fall-through (which redirects to the download folder of the latest release) they will end in 404 errors. Instead, we redirect those IRIs to point to the master branch.

See https://github.com/obophenotype/cell-ontology/issues/3119.