### PR TITLE
Update pcl.yml to add bds.owl link

### DIFF
--- a/config/pcl.yml
+++ b/config/pcl.yml
@@ -44,6 +44,9 @@ entries:
 - prefix: /about/
   replacement: https://github.com/obophenotype/provisional_cell_ontology#readme
 
+- exact: /bds/bds.owl
+  replacement: https://raw.githubusercontent.com/obophenotype/brain_data_standards_ontologies/master/bdso.owl
+  
 - exact: /bds/kg
   replacement: https://knowledge-graph-ebi.brain.allentech.org/browser/
   


### PR DESCRIPTION
Brain data standards ontology link added: `/bds/bds.owl` 

This URL was used by the BDSO paper:
> The latest release of the ontology is available for download from http://purl.obolibrary.org/obo/pcl/bds/bds.owl.