### PR TITLE
Add PURL redirect for DO translations

### DIFF
--- a/config/doid.yml
+++ b/config/doid.yml
@@ -34,7 +34,7 @@ entries:
 - regex: ^/obo/doid/releases/([^\s/]+)/translations/(\S+)$
   replacement: https://raw.githubusercontent.com/DiseaseOntology/HumanDiseaseOntology/v$1/src/ontology/releases/translations/$2
   tests:
-  - from: /releases/2020-01-31/translations/doid-international.owl
+  - from: /releases/2025-01-31/translations/doid-international.owl
     to: https://raw.githubusercontent.com/DiseaseOntology/HumanDiseaseOntology/v2025-01-31/src/ontology/releases/translations/doid-international.owl
 
 - regex: ^/obo/doid/releases/([^\s/]+)/(\S+)$

--- a/config/doid.yml
+++ b/config/doid.yml
@@ -25,6 +25,18 @@ entries:
   - from: /imports/ro_import.owl
     to: https://raw.githubusercontent.com/DiseaseOntology/HumanDiseaseOntology/main/src/ontology/imports/ro_import.owl
 
+- prefix: /translations/
+  replacement: https://raw.githubusercontent.com/DiseaseOntology/HumanDiseaseOntology/main/src/ontology/releases/translations/
+  tests:
+  - from: /translations/doid-es.owl
+    to: https://raw.githubusercontent.com/DiseaseOntology/HumanDiseaseOntology/main/src/ontology/releases/translations/doid-es.owl
+
+- regex: ^/obo/doid/releases/([^\s/]+)/translations/(\S+)$
+  replacement: https://raw.githubusercontent.com/DiseaseOntology/HumanDiseaseOntology/v$1/src/ontology/releases/translations/$2
+  tests:
+  - from: /releases/2020-01-31/translations/doid-international.owl
+    to: https://raw.githubusercontent.com/DiseaseOntology/HumanDiseaseOntology/v2025-01-31/src/ontology/releases/translations/doid-international.owl
+
 - regex: ^/obo/doid/releases/([^\s/]+)/(\S+)$
   replacement: https://raw.githubusercontent.com/DiseaseOntology/HumanDiseaseOntology/v$1/src/ontology/$2
   tests:


### PR DESCRIPTION
Adds redirects for ontology translation files, currently in Spanish (owl/obo) or international (owl) only.

It was decided that these files should have PURLs formatted like this: `/obo/doid/translations/<file name>`, with versionIRIs that have a similar pattern, and be located in the `src/ontology/releases/translations/` directory of HumanDiseaseOntology GitHub repository. This update is necessary because existing DO PURLs do not redirect to this "releases" directory and  these translation files are only saved in this `releases/translations` location in the repository.