### PR TITLE
redirecting purls to planteome for PO, TO and PECO

### DIFF
--- a/config/obo.yml
+++ b/config/obo.yml
@@ -160,6 +160,30 @@ entries:
   - from: /OBA_VT0000002
     to: https://www.ebi.ac.uk/ols4/ontologies/oba/entities/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FOBA_VT0000002
 
+# Term redirects for PO
+- regex: ^/obo/PO_(\d+)$
+  replacement: https://browser.planteome.org/amigo/term/PO:$1
+  status: see other
+  tests:
+  - from: /PO_0009012
+    to: https://browser.planteome.org/amigo/term/PO:0009012
+
+# Term redirects for TO
+- regex: ^/obo/TO_(\d+)$
+  replacement: https://browser.planteome.org/amigo/term/TO:$1
+  status: see other
+  tests:
+  - from: /TO_0000001
+    to: https://browser.planteome.org/amigo/term/TO:0000001
+
+# Term redirects for PECO
+- regex: ^/obo/PECO_(\d+)$
+  replacement: https://browser.planteome.org/amigo/term/PECO:$1
+  status: see other
+  tests:
+  - from: /PECO_0007359
+    to: https://browser.planteome.org/amigo/term/PECO:0007359
+
 ### OBO Format Specification
 - exact: /oboformat/
   replacement: http://owlcollab.github.io/oboformat/doc/obo-syntax.html

--- a/config/peco.yml
+++ b/config/peco.yml
@@ -7,7 +7,7 @@ products:
 - peco.owl: https://raw.githubusercontent.com/Planteome/plant-experimental-conditions-ontology/master/peco.owl
 - peco.OBO: https://raw.githubusercontent.com/Planteome/plant-experimental-conditions-ontology/master/peco.obo
 
-term_browser: ontobee
+term_browser: custom
 example_terms:
 - PECO_0007359
 

--- a/config/po.yml
+++ b/config/po.yml
@@ -17,6 +17,6 @@ entries:
 - prefix: /releases/
   replacement: https://raw.githubusercontent.com/Planteome/plant-ontology/v
   
-term_browser: ontobee
+term_browser: custom
 example_terms:
 - PO_0009012

--- a/config/to.yml
+++ b/config/to.yml
@@ -7,7 +7,7 @@ products:
 - to.owl: https://raw.githubusercontent.com/Planteome/plant-trait-ontology/master/to.owl
 - to.obo: https://raw.githubusercontent.com/Planteome/plant-trait-ontology/master/to.obo
 
-term_browser: ontobee
+term_browser: custom
 example_terms:
 - TO_0000001
 


### PR DESCRIPTION
@cooperl09 
We would like to redirect the PURLs of the Planteome ontologies (PO, TO and PECO for now) to our Planteome browser instead of Ontobee (see [issue](https://github.com/Planteome/plant-trait-ontology/issues/511)) 