### PR TITLE
Redirect NCBITaxon PURLs to official NCBI site

### DIFF
--- a/config/ncbitaxon.yml
+++ b/config/ncbitaxon.yml
@@ -11,7 +11,7 @@ products:
 - ncbitaxon.obo.gz: https://github.com/obophenotype/ncbitaxon/releases/latest/download/ncbitaxon.obo.gz
 - ncbitaxon.json.gz: https://github.com/obophenotype/ncbitaxon/releases/latest/download/ncbitaxon.json.gz
 
-term_browser: ontobee
+term_browser: custom
 example_terms:
 - NCBITaxon_1
 

--- a/config/obo.yml
+++ b/config/obo.yml
@@ -88,6 +88,14 @@ entries:
   - from: /HAO_0000000
     to: http://api.hymao.org/api/ontology/ontology_class/HAO_0000000
 
+# Term redirects for NCBI Taxonomy
+- regex: ^/obo/NCBITaxon_(\d+)$
+  replacement: https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=$1
+  status: see other
+  tests:
+  - from: /NCBITaxon_9606
+    to: https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=9606
+
 # Term redirects for PR
 # Match digits or UniProt ID, see http://www.uniprot.org/help/accession_numbers
 - regex: ^/obo/PR_(\d+|[OPQ][0-9][A-Z0-9]{3}[0-9](-\d+)?|[A-NR-Z][0-9]([A-Z][A-Z0-9]{2}[0-9]){1,2}(-\d+)?)$


### PR DESCRIPTION
Resolves #1010 from https://github.com/obophenotype/ncbitaxon/issues/117

I found this issue at the bottom of my inbox and decided to finally take care of it.

Note that there are non-numeric IDs for ranks and stuff in NCBITaxon, some using `#` fragments. I think that none of them ever resolved. Most were replaced by TAXRANK terms. If someone wants to do a forensic analysis of this, be my guest.