### PR TITLE
Change EHDAA2 product URLs to GitHub repository links

### DIFF
--- a/config/ehdaa2.yml
+++ b/config/ehdaa2.yml
@@ -4,8 +4,8 @@ idspace: EHDAA2
 base_url: /obo/ehdaa2
 
 products:
-- ehdaa2.owl: http://ontologies.berkeleybop.org/ehdaa2.owl
-- ehdaa2.obo: http://ontologies.berkeleybop.org/ehdaa2.obo
+- ehdaa2.owl: https://raw.githubusercontent.com/obophenotype/human-developmental-anatomy-ontology/refs/heads/master/src/ontology/ehdaa2.owl
+- ehdaa2.obo: https://raw.githubusercontent.com/obophenotype/human-developmental-anatomy-ontology/refs/heads/master/src/ontology/ehdaa2.obo
 
 term_browser: ontobee
 example_terms:


### PR DESCRIPTION
Updated product URLs for ehdaa2.owl and ehdaa2.obo to point to the latest GitHub repository.