### PR TITLE
Add dated FLOPO release routes

### DIFF
--- a/config/flopo.yml
+++ b/config/flopo.yml
@@ -1,4 +1,4 @@
-# PURL configuration for http://purl.obolibrary.org/obo/fma
+# PURL configuration for http://purl.obolibrary.org/obo/flopo
 
 idspace: FLOPO
 base_url: /obo/flopo
@@ -7,3 +7,12 @@ products:
 - flopo.owl: https://github.com/flora-phenotype-ontology/flopoontology/raw/master/ontology/flopo.owl
 
 term_browser: custom
+
+entries:
+- prefix: /releases/
+  replacement: https://github.com/flora-phenotype-ontology/flopoontology/releases/download/v
+  tests:
+  - from: /releases/2026-07-15/flopo.owl
+    to: https://github.com/flora-phenotype-ontology/flopoontology/releases/download/v2026-07-15/flopo.owl
+  - from: /releases/2026-07-31/flopo.owl
+    to: https://github.com/flora-phenotype-ontology/flopoontology/releases/download/v2026-07-31/flopo.owl


### PR DESCRIPTION
Add the missing `/releases/` route for FLOPO so immutable ontology version IRIs resolve to the matching GitHub release assets.

This includes explicit redirect tests for the archived 2026-07-15 release and the new 2026-07-31 upper-level rebuild. The generated Apache rule was validated locally with `tools/translate_yaml.py`.

Release assets:
- https://github.com/flora-phenotype-ontology/flopoontology/releases/tag/v2026-07-15
- https://github.com/flora-phenotype-ontology/flopoontology/releases/tag/v2026-07-31